### PR TITLE
Fix the problem that mac m1 cannot run docker image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+.github
+.git
+.vscode
 target
 data
 !resources

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
-*
+target
+data
 !resources
 !target/release/oak
 !target/release/neumann-collator
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "oak-node"
-version = "0.1.0"
+version = "1.2.1"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",

--- a/docker/neumann/Dockerfile
+++ b/docker/neumann/Dockerfile
@@ -1,8 +1,17 @@
-FROM ubuntu:20.04
+# This is the build stage for OAK. Here we create the binary in a temporary image.
+FROM docker.io/paritytech/ci-linux:production as builder
 
+WORKDIR /build
+COPY . /build
+
+RUN cargo build --locked --release
+
+# This is the 2nd stage: a very small image where we copy the OAK binary."
+FROM docker.io/library/ubuntu:20.04
+
+ARG USERNAME=oak
 ARG PROFILE=release
 ARG BINARY=neumann-collator
-ARG USERNAME=oak
 
 LABEL maintainer "contact@oak.tech"
 LABEL description="Binary for Neumann Collator"
@@ -23,7 +32,7 @@ RUN apt-get update && apt-get install -y curl && \
 USER $USERNAME
 
 # Copy files
-COPY --chown=$USERNAME ./target/$PROFILE/$BINARY /$USERNAME/$BINARY
+COPY --chown=$USERNAME --from=builder /build/target/release/$BINARY  /$USERNAME/$BINARY
 COPY --chown=$USERNAME ./resources /$USERNAME/resources
 
 # Open network port
@@ -38,6 +47,7 @@ EXPOSE 30333 30334 9933 9944 9615
 VOLUME ["/data"]
 
 # Change work directory
-WORKDIR $USERNAME
+WORKDIR /$USERNAME
 
 ENTRYPOINT ["./neumann-collator"]
+

--- a/docker/neumann/build.sh
+++ b/docker/neumann/build.sh
@@ -15,7 +15,7 @@ PROJECT=neumann
 # Build the image
 echo "Building ${USER}/${PROJECT}:latest docker image, hang on!"
 time docker build -f ./docker/neumann/Dockerfile -t ${USER}/${PROJECT}:latest .
-docker tag ${USER}/${PROJECT}:latest ${USER}/${PROJECT}:v${VERSION}
+docker tag ${USER}/${PROJECT}:latest ${USER}/${PROJECT}:${VERSION}
 
 # Show the list of available images for this repo
 echo "Image is ready"

--- a/docker/neumann/build.sh
+++ b/docker/neumann/build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+pushd .
+
+# The following line ensure we run from the project root
+PROJECT_ROOT=`git rev-parse --show-toplevel`
+cd $PROJECT_ROOT
+
+# Find the current version from Cargo.toml
+VERSION=`grep "^version" ./node/Cargo.toml | egrep -o "([0-9\.]+)"`
+USER=oaknetwork
+PROJECT=neumann
+
+# Build the image
+echo "Building ${USER}/${PROJECT}:latest docker image, hang on!"
+time docker build -f ./docker/neumann/Dockerfile -t ${USER}/${PROJECT}:latest .
+docker tag ${USER}/${PROJECT}:latest ${USER}/${PROJECT}:v${VERSION}
+
+# Show the list of available images for this repo
+echo "Image is ready"
+docker images | grep ${PROJECT}
+
+popd

--- a/docker/neumann/build.sh
+++ b/docker/neumann/build.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
+# Please execute this script in the project root directory.
 set -e
-
-pushd .
 
 # The following line ensure we run from the project root
 PROJECT_ROOT=`git rev-parse --show-toplevel`
@@ -20,5 +19,3 @@ docker tag ${USER}/${PROJECT}:latest ${USER}/${PROJECT}:${VERSION}
 # Show the list of available images for this repo
 echo "Image is ready"
 docker images | grep ${PROJECT}
-
-popd

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oak-node"
-version = "0.1.0"
+version = "1.2.1"
 authors = ["OAK Developement Team"]
 description = "Automation-first Blockchain"
 license = "GPL-3.0"


### PR DESCRIPTION
Refer to:
https://github.com/paritytech/polkadot/blob/master/scripts/dockerfiles/polkadot/polkadot_builder.Dockerfile
https://github.com/paritytech/polkadot/blob/master/scripts/dockerfiles/polkadot/build.sh

Usage:
```
sh docker/neumann/build.sh
```

**!!!This script will read the version configured in node/Cargo.toml as the version of the docker image. Therefore, when updating the node's code, remember to update the version field of this file.**

Building the image is possible on any host having docker installed and will build OAK inside Docker. That also means that no Rust toolchain is required on the host machine for the build to succeed.
