### PR TITLE
split update queue behavior for missed and scheduled queues

### DIFF
--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// #![cfg(feature = "runtime-benchmarks")]
+#![cfg(feature = "runtime-benchmarks")]
 
 use super::*;
 use frame_benchmarking::{account, benchmarks};

--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -308,10 +308,9 @@ benchmarks! {
 
 	shift_missed_tasks {
 		let caller: T::AccountId = account("callerName", 0, SEED);
-		let missed_tasks = vec![];
 		let last_time_slot: u64 = 120;
 		let new_time_slot: u64 = 240;
 		let diff = 1;
 		schedule_notify_tasks::<T>(caller.clone(), new_time_slot, 1);
-	}: { AutomationTime::<T>::shift_missed_tasks(missed_tasks, last_time_slot, diff) }
+	}: { AutomationTime::<T>::shift_missed_tasks(last_time_slot, diff) }
 }

--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -289,8 +289,6 @@ benchmarks! {
 				<Tasks<T>>::insert(task_id, task);
 			}
 		}
-		let time_moment: u32 = (current_time * 1000).try_into().unwrap();
-		<pallet_timestamp::Pallet<T>>::set_timestamp(time_moment.into());
 	}: { AutomationTime::<T>::append_to_missed_tasks(current_time, last_time_slot, weight_left) }
 
 	update_scheduled_task_queue {

--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(feature = "runtime-benchmarks")]
+// #![cfg(feature = "runtime-benchmarks")]
 
 use super::*;
 use frame_benchmarking::{account, benchmarks};
@@ -268,48 +268,50 @@ benchmarks! {
 	*/
 
 	update_task_queue_overhead {
-	}: { AutomationTime::<T>::update_task_queue() }
-
-	update_task_queue_max_current {
-		let caller: T::AccountId = account("callerName", 0, SEED);
-		let current_time: u64 = 180;
-		let next_time: u64 = 240;
-		
-		schedule_notify_tasks::<T>(caller.clone(), current_time, T::MaxTasksPerSlot::get());
-	}: { AutomationTime::<T>::update_task_queue() }
+		let weight_left = 500_000_000_000;
+	}: { AutomationTime::<T>::update_task_queue(weight_left) }
 
 	append_to_missed_tasks {
+		let weight_left = 500_000_000_000;
 		let v in 0 .. 2;
 		let caller: T::AccountId = account("callerName", 0, SEED);
 		let last_time_slot: u64 = 60;
 		let time = last_time_slot;
-		let missed_tasks: Vec<T::Hash> = vec![];
+		let time_change: u64 = (v * 60).into();
+		let current_time = last_time_slot + time_change;
 
 		for i in 0..v {
-			let time = time.saturating_add(60);
-			let provided_id: Vec<u8> = vec![i.saturated_into::<u8>()];
-			let task_id = AutomationTime::<T>::schedule_task(caller.clone(), provided_id.clone(), time.into()).unwrap();
-			let task = Task::<T>::create_event_task(caller.clone(), provided_id, time.into(), vec![4, 5, 6]);
-			<Tasks<T>>::insert(task_id, task);
+			for j in 0..1 {
+				let time = time.saturating_add(60);
+				let provided_id: Vec<u8> = vec![i.saturated_into::<u8>(), j.saturated_into::<u8>()];
+				let task_id = AutomationTime::<T>::schedule_task(caller.clone(), provided_id.clone(), time.into()).unwrap();
+				let task = Task::<T>::create_event_task(caller.clone(), provided_id, time.into(), vec![4, 5, 6]);
+				<Tasks<T>>::insert(task_id, task);
+			}
 		}
-	}: { AutomationTime::<T>::append_to_missed_tasks(missed_tasks, last_time_slot, v.into()) }
-
-	update_task_queue_max_current_and_next {
-		let caller: T::AccountId = account("callerName", 0, SEED);
-		let last_time: u64 = 120;
-		let current_time: u64 = 180;
-		let next_time: u64 = 240;
 		let time_moment: u32 = (current_time * 1000).try_into().unwrap();
+		<pallet_timestamp::Pallet<T>>::set_timestamp(time_moment.into());
+	}: { AutomationTime::<T>::append_to_missed_tasks(current_time, last_time_slot, weight_left) }
 
-		schedule_notify_tasks::<T>(caller.clone(), current_time, T::MaxTasksPerSlot::get());
+	update_scheduled_task_queue {
+		let caller: T::AccountId = account("callerName", 0, SEED);
+		let last_time_slot: u64 = 120;
+		let current_time = 180;
 
 		for i in 0..T::MaxTasksPerSlot::get() {
-			let provided_id: Vec<u8> = vec![i.saturated_into::<u8>(), 180];
-			let task_id = AutomationTime::<T>::schedule_task(caller.clone(), provided_id.clone(), next_time.into()).unwrap();
-			let task = Task::<T>::create_event_task(caller.clone(), provided_id, next_time.into(), vec![4, 5, 6]);
+			let provided_id: Vec<u8> = vec![i.saturated_into::<u8>()];
+			let task_id = AutomationTime::<T>::schedule_task(caller.clone(), provided_id.clone(), current_time.into()).unwrap();
+			let task = Task::<T>::create_event_task(caller.clone(), provided_id, current_time.into(), vec![4, 5, 6]);
 			<Tasks<T>>::insert(task_id, task);
 		}
-		<pallet_timestamp::Pallet<T>>::set_timestamp(time_moment.into());
-		<LastTimeSlot<T>>::put(last_time);
-	}: { AutomationTime::<T>::update_task_queue() }
+	}: { AutomationTime::<T>::update_scheduled_task_queue(current_time, last_time_slot) }
+
+	shift_missed_tasks {
+		let caller: T::AccountId = account("callerName", 0, SEED);
+		let missed_tasks = vec![];
+		let last_time_slot: u64 = 120;
+		let new_time_slot: u64 = 240;
+		let diff = 1;
+		schedule_notify_tasks::<T>(caller.clone(), new_time_slot, 1);
+	}: { AutomationTime::<T>::shift_missed_tasks(missed_tasks, last_time_slot, diff) }
 }

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -193,10 +193,6 @@ pub mod pallet {
 	#[pallet::getter(fn is_shutdown)]
 	pub type Shutdown<T: Config> = StorageValue<_, bool, ValueQuery>;
 
-	#[pallet::storage]
-	#[pallet::getter(fn get_automation_time_storage_version)]
-	pub type AutomationTimeStorageVersion<T: Config> = StorageValue<_, u16>;
-
 	#[pallet::error]
 	pub enum Error<T> {
 		/// Time must end in a whole minute.

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -39,6 +39,7 @@ mod tests;
 
 mod benchmarking;
 pub mod weights;
+pub mod migrations;
 
 mod exchange;
 pub use exchange::*;
@@ -189,6 +190,10 @@ pub mod pallet {
 	#[pallet::getter(fn is_shutdown)]
 	pub type Shutdown<T: Config> = StorageValue<_, bool, ValueQuery>;
 
+	#[pallet::storage]
+	#[pallet::getter(fn get_automation_time_storage_version)]
+	pub type AutomationTimeStorageVersion<T: Config> = StorageValue<_, u16>;
+
 	#[pallet::error]
 	pub enum Error<T> {
 		/// Time must end in a whole minute.
@@ -267,6 +272,10 @@ pub mod pallet {
 
 			let max_weight: Weight = T::MaxWeightPercentage::get().mul_floor(T::MaxBlockWeight::get());
 			Self::trigger_tasks(max_weight)
+		}
+
+		fn on_runtime_upgrade() -> Weight {
+			migrations::v1::migrate::<T>()
 		}
 	}
 

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -54,6 +54,7 @@ use sp_runtime::{
 	Perbill,
 };
 use sp_std::{vec, vec::Vec};
+use log::info;
 
 pub use weights::WeightInfo;
 
@@ -521,6 +522,8 @@ pub mod pallet {
 			};
 
 			if let Some((last_time_slot, last_missed_slot)) = Self::get_last_slot() {
+				info!("last_time_slot: {}", last_time_slot);
+				info!("last_missed_slot: {}", last_missed_slot);
 				let missed_queue_allotted_weight = allotted_weight
 					.saturating_sub(T::DbWeight::get().reads(1 as Weight))
 					.saturating_sub(T::DbWeight::get().writes(1 as Weight))

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -187,6 +187,9 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn get_last_slot)]
+	// NOTE: The 2 UnixTime stamps represent (last_time_slot, last_missed_slot).
+	// `last_time_slot` represents the last time slot that the task queue was updated.
+	// `last_missed_slot` represents the last scheduled slot where the missed queue has checked for missed tasks.
 	pub type LastTimeSlot<T: Config> = StorageValue<_, (UnixTime, UnixTime)>;
 
 	#[pallet::storage]
@@ -526,8 +529,6 @@ pub mod pallet {
 			};
 
 			if let Some((last_time_slot, last_missed_slot)) = Self::get_last_slot() {
-				info!("last_time_slot: {}", last_time_slot);
-				info!("last_missed_slot: {}", last_missed_slot);
 				let missed_queue_allotted_weight = allotted_weight
 					.saturating_sub(T::DbWeight::get().reads(1 as Weight))
 					.saturating_sub(T::DbWeight::get().writes(1 as Weight))

--- a/pallets/automation-time/src/migrations.rs
+++ b/pallets/automation-time/src/migrations.rs
@@ -21,6 +21,7 @@ use super::*;
 		).expect("Must have last slot value");
 
     // TODO: (jzhou) Gate migration on not having storage version
+    // TODO: (jzhou) What if stored_data is None?
     let storage_version = AutomationTimeStorageVersion::<T>::get();
     if storage_version == None || storage_version < Some(1) {
       LastTimeSlot::<T>::put((stored_data, stored_data));

--- a/pallets/automation-time/src/migrations.rs
+++ b/pallets/automation-time/src/migrations.rs
@@ -3,9 +3,9 @@ use frame_support::traits::Get;
 use log::info;
 
 pub mod v1 {
-	use frame_support::{migration::get_storage_value};
+	use frame_support::{migration::get_storage_value, traits::StorageVersion};
 
-  use crate::{LastTimeSlot, AutomationTimeStorageVersion};
+  use crate::{LastTimeSlot, Pallet};
 
 use super::*;
 
@@ -22,7 +22,7 @@ use super::*;
 
     LastTimeSlot::<T>::put((stored_data, stored_data));
     info!(target: "automation-time", "Completed automation-time migration to v1");
-    AutomationTimeStorageVersion::<T>::put(1);
+    StorageVersion::new(1).put::<Pallet<T>>();
     T::DbWeight::get().reads_writes(1, 1)
 	}
 }

--- a/pallets/automation-time/src/migrations.rs
+++ b/pallets/automation-time/src/migrations.rs
@@ -20,17 +20,9 @@ use super::*;
       &[],
 		).expect("Must have last slot value");
 
-    // TODO: (jzhou) Gate migration on not having storage version
-    // TODO: (jzhou) What if stored_data is None?
-    let storage_version = AutomationTimeStorageVersion::<T>::get();
-    if storage_version == None || storage_version < Some(1) {
-      LastTimeSlot::<T>::put((stored_data, stored_data));
-      info!(target: "automation-time", "Completed automation-time migration to v1");
-      AutomationTimeStorageVersion::<T>::put(1);
-      T::DbWeight::get().reads_writes(1, 1)
-    } else {
-      info!("migration already run before");
-      0
-    }
+    LastTimeSlot::<T>::put((stored_data, stored_data));
+    info!(target: "automation-time", "Completed automation-time migration to v1");
+    AutomationTimeStorageVersion::<T>::put(1);
+    T::DbWeight::get().reads_writes(1, 1)
 	}
 }

--- a/pallets/automation-time/src/migrations.rs
+++ b/pallets/automation-time/src/migrations.rs
@@ -1,0 +1,35 @@
+use crate::{Config, Weight};
+use frame_support::traits::Get;
+use log::info;
+
+pub mod v1 {
+	use frame_support::{migration::get_storage_value};
+
+  use crate::{LastTimeSlot, AutomationTimeStorageVersion};
+
+use super::*;
+
+	pub fn migrate<T: Config>() -> Weight {
+		info!(target: "automation-time", "Migrating automation-time v1");
+    let pallet_prefix: &[u8] = b"AutomationTime";
+		let storage_item_prefix: &[u8] = b"LastTimeSlot";
+
+		let stored_data = get_storage_value::<u64>(
+			pallet_prefix,
+			storage_item_prefix,
+      &[],
+		).expect("Must have last slot value");
+
+    // TODO: (jzhou) Gate migration on not having storage version
+    let storage_version = AutomationTimeStorageVersion::<T>::get();
+    if storage_version == None || storage_version < Some(1) {
+      LastTimeSlot::<T>::put((stored_data, stored_data));
+      info!(target: "automation-time", "Completed automation-time migration to v1");
+      AutomationTimeStorageVersion::<T>::put(1);
+      T::DbWeight::get().reads_writes(1, 1)
+    } else {
+      info!("migration already run before");
+      0
+    }
+	}
+}

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -118,8 +118,9 @@ impl pallet_timestamp::Config for Test {
 parameter_types! {
 	pub const MaxTasksPerSlot: u32 = 2;
 	pub const MaxScheduleSeconds: u64 = 1 * 24 * 60 * 60;
-	pub const MaxBlockWeight: Weight = 900_000;
+	pub const MaxBlockWeight: Weight = 1_000_000;
 	pub const MaxWeightPercentage: Perbill = Perbill::from_percent(10);
+	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
 	pub const SecondsPerBlock: u64 = 12;
 	pub const ExecutionWeightFee: Balance = 12;
 }
@@ -177,13 +178,13 @@ impl<Test: frame_system::Config> pallet_automation_time::WeightInfo for MockWeig
 	fn update_task_queue_overhead() -> Weight {
 		10_000
 	}
-	fn update_task_queue_max_current() -> Weight {
-		20_000
-	}
 	fn append_to_missed_tasks(v: u32, ) -> Weight {
 		(20_000 * v).into()
 	}
-	fn update_task_queue_max_current_and_next() -> Weight {
+	fn update_scheduled_task_queue() -> Weight {
+		20_000
+	}
+	fn shift_missed_tasks() -> Weight {
 		20_000
 	}
 }
@@ -202,6 +203,7 @@ impl pallet_automation_time::Config for Test {
 	type MaxScheduleSeconds = MaxScheduleSeconds;
 	type MaxBlockWeight = MaxBlockWeight;
 	type MaxWeightPercentage = MaxWeightPercentage;
+	type UpdateQueueRatio = UpdateQueueRatio;
 	type SecondsPerBlock = SecondsPerBlock;
 	type WeightInfo = MockWeight<Test>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -396,6 +396,7 @@ fn force_cancel_task_works() {
 // 10_000: update task queue function overhead (update_task_queue_overhead)
 // 20_000: update task queue for scheduled tasks (update_scheduled_task_queue)
 // 20_000v: for each old time slot to missed tasks (append_to_missed_tasks)
+// 20_000: to move a single time slot to missed tasks (shift_missed_tasks)
 
 #[test]
 fn trigger_tasks_handles_first_run() {

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -467,8 +467,8 @@ fn trigger_tasks_limits_missed_slots() {
 		let missing_task_id0 = add_task_to_task_queue(ALICE, vec![40], Action::Notify { message: vec![40] });
 		assert_eq!(AutomationTime::get_missed_queue().len(), 0);
 		Timestamp::set_timestamp((SCHEDULED_TIME - 420) * 1_000);
-		schedule_task(ALICE, vec![50], SCHEDULED_TIME - 60, vec![50]);
-		schedule_task(ALICE, vec![60], SCHEDULED_TIME - 120, vec![50]);
+		let missing_task_id1 = schedule_task(ALICE, vec![50], SCHEDULED_TIME - 60, vec![50]);
+		let missing_task_id2 = schedule_task(ALICE, vec![60], SCHEDULED_TIME - 120, vec![50]);
 		let missing_task_id3 = schedule_task(ALICE, vec![70], SCHEDULED_TIME - 180, vec![50]);
 		let missing_task_id4 = schedule_task(ALICE, vec![80], SCHEDULED_TIME - 240, vec![50]);
 		let missing_task_id5 = schedule_task(ALICE, vec![90], SCHEDULED_TIME - 300, vec![50]);
@@ -494,6 +494,24 @@ fn trigger_tasks_limits_missed_slots() {
 			);
 		} else {
 			panic!("trigger_tasks_limits_missed_slots test did not have LastTimeSlot updated")
+		}
+		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME - 120) {
+			None => {
+				panic!("A task should be scheduled")
+			},
+			Some(task_ids) => {
+				assert_eq!(task_ids.len(), 1);
+				assert_eq!(task_ids[0], missing_task_id2);
+			},
+		}
+		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME - 60) {
+			None => {
+				panic!("A task should be scheduled")
+			},
+			Some(task_ids) => {
+				assert_eq!(task_ids.len(), 1);
+				assert_eq!(task_ids[0], missing_task_id1);
+			},
 		}
 	})
 }

--- a/pallets/automation-time/src/weights.rs
+++ b/pallets/automation-time/src/weights.rs
@@ -50,9 +50,9 @@ pub trait WeightInfo {
 	fn run_tasks_many_found(v: u32, ) -> Weight;
 	fn run_tasks_many_missing(v: u32, ) -> Weight;
 	fn update_task_queue_overhead() -> Weight;
-	fn update_task_queue_max_current() -> Weight;
 	fn append_to_missed_tasks(v: u32, ) -> Weight;
-	fn update_task_queue_max_current_and_next() -> Weight;
+	fn update_scheduled_task_queue() -> Weight;
+	fn shift_missed_tasks() -> Weight;
 }
 
 /// Weight functions for `pallet_automation_time`.
@@ -63,7 +63,7 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
 	fn schedule_notify_task_empty() -> Weight {
-		(37_000_000 as Weight)
+		(39_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
@@ -72,7 +72,7 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
 	fn schedule_notify_task_full() -> Weight {
-		(54_000_000 as Weight)
+		(56_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
@@ -126,7 +126,7 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
 	fn force_cancel_scheduled_task_full() -> Weight {
-		(30_000_000 as Weight)
+		(29_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
@@ -150,32 +150,32 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	fn run_missed_tasks_many_found(v: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 89_000
-			.saturating_add((10_437_000 as Weight).saturating_mul(v as Weight))
+			// Standard Error: 0
+			.saturating_add((11_000_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(v as Weight)))
 	}
 	// Storage: AutomationTime Tasks (r:1 w:0)
 	fn run_missed_tasks_many_missing(v: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 59_000
-			.saturating_add((8_875_000 as Weight).saturating_mul(v as Weight))
+			// Standard Error: 0
+			.saturating_add((9_000_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
 	}
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	// Storage: System Account (r:2 w:2)
 	fn run_tasks_many_found(v: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 0
-			.saturating_add((29_000_000 as Weight).saturating_mul(v as Weight))
+			// Standard Error: 77_000
+			.saturating_add((29_250_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(v as Weight)))
 			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(v as Weight)))
 	}
 	// Storage: AutomationTime Tasks (r:1 w:0)
 	fn run_tasks_many_missing(v: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 70_000
-			.saturating_add((8_812_000 as Weight).saturating_mul(v as Weight))
+			// Standard Error: 77_000
+			.saturating_add((8_750_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
 	}
 	// Storage: Timestamp Now (r:1 w:0)
@@ -183,29 +183,29 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 		(1_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 	}
-	// Storage: Timestamp Now (r:1 w:0)
-	// Storage: AutomationTime LastTimeSlot (r:1 w:1)
-	fn update_task_queue_max_current() -> Weight {
-		(4_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-	}
-	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
-	fn append_to_missed_tasks(v: u32, ) -> Weight {
-		(219_000 as Weight)
-			// Standard Error: 59_000
-			.saturating_add((2_625_000 as Weight).saturating_mul(v as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
-			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(v as Weight)))
-	}
-	// Storage: Timestamp Now (r:1 w:0)
-	// Storage: AutomationTime LastTimeSlot (r:1 w:1)
-	// Storage: AutomationTime TaskQueue (r:1 w:1)
+	// Storage: AutomationTime TaskQueue (r:1 w:0)
 	// Storage: AutomationTime MissedQueue (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
-	fn update_task_queue_max_current_and_next() -> Weight {
-		(26_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+	fn append_to_missed_tasks(v: u32, ) -> Weight {
+		(2_823_000 as Weight)
+			// Standard Error: 71_000
+			.saturating_add((1_906_000 as Weight).saturating_mul(v as Weight))
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(v as Weight)))
+	}
+	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
+	// Storage: AutomationTime TaskQueue (r:0 w:1)
+	fn update_scheduled_task_queue() -> Weight {
+		(17_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
+	fn shift_missed_tasks() -> Weight {
+		(4_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 }

--- a/pallets/automation-time/src/weights.rs
+++ b/pallets/automation-time/src/weights.rs
@@ -63,7 +63,7 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
 	fn schedule_notify_task_empty() -> Weight {
-		(39_000_000 as Weight)
+		(38_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
@@ -72,7 +72,7 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
 	fn schedule_notify_task_full() -> Weight {
-		(56_000_000 as Weight)
+		(54_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
@@ -134,7 +134,7 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime ScheduledTasks (r:1 w:0)
 	// Storage: AutomationTime TaskQueue (r:1 w:1)
 	fn force_cancel_overflow_task() -> Weight {
-		(30_000_000 as Weight)
+		(29_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
@@ -150,8 +150,8 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	fn run_missed_tasks_many_found(v: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 0
-			.saturating_add((11_000_000 as Weight).saturating_mul(v as Weight))
+			// Standard Error: 59_000
+			.saturating_add((10_875_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(v as Weight)))
 	}
@@ -166,16 +166,16 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: System Account (r:2 w:2)
 	fn run_tasks_many_found(v: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 77_000
-			.saturating_add((29_250_000 as Weight).saturating_mul(v as Weight))
+			// Standard Error: 62_000
+			.saturating_add((29_937_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(v as Weight)))
 			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(v as Weight)))
 	}
 	// Storage: AutomationTime Tasks (r:1 w:0)
 	fn run_tasks_many_missing(v: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 77_000
-			.saturating_add((8_750_000 as Weight).saturating_mul(v as Weight))
+			// Standard Error: 0
+			.saturating_add((9_000_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
 	}
 	// Storage: Timestamp Now (r:1 w:0)
@@ -183,28 +183,28 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 		(1_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 	}
-	// Storage: AutomationTime TaskQueue (r:1 w:0)
 	// Storage: AutomationTime MissedQueue (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
 	fn append_to_missed_tasks(v: u32, ) -> Weight {
-		(2_823_000 as Weight)
-			// Standard Error: 71_000
-			.saturating_add((1_906_000 as Weight).saturating_mul(v as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+		(1_365_000 as Weight)
+			// Standard Error: 115_000
+			.saturating_add((2_000_000 as Weight).saturating_mul(v as Weight))
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(v as Weight)))
 	}
+	// Storage: AutomationTime TaskQueue (r:1 w:1)
+	// Storage: AutomationTime MissedQueue (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
-	// Storage: AutomationTime TaskQueue (r:0 w:1)
 	fn update_scheduled_task_queue() -> Weight {
-		(17_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		(22_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
 	fn shift_missed_tasks() -> Weight {
-		(4_000_000 as Weight)
+		(3_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}

--- a/pallets/valve/src/mock.rs
+++ b/pallets/valve/src/mock.rs
@@ -121,6 +121,7 @@ parameter_types! {
 	pub const MaxScheduleSeconds: u64 = 1 * 24 * 60 * 60;
 	pub const MaxBlockWeight: Weight = 1200_000;
 	pub const MaxWeightPercentage: Perbill = Perbill::from_percent(10);
+	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
 	pub const SecondsPerBlock: u64 = 12;
 	pub const ExecutionWeightFee: Balance = 12;
 }
@@ -180,13 +181,13 @@ impl<Test: frame_system::Config> pallet_automation_time::WeightInfo
 	fn update_task_queue_overhead() -> Weight {
 		0
 	}
-	fn update_task_queue_max_current() -> Weight {
-		0
-	}
 	fn append_to_missed_tasks(v: u32, ) -> Weight {
 		0
 	}
-	fn update_task_queue_max_current_and_next() -> Weight {
+	fn update_scheduled_task_queue() -> Weight {
+		0
+	}
+	fn shift_missed_tasks() -> Weight {
 		0
 	}
 }
@@ -205,6 +206,7 @@ impl pallet_automation_time::Config for Test {
 	type MaxScheduleSeconds = MaxScheduleSeconds;
 	type MaxBlockWeight = MaxBlockWeight;
 	type MaxWeightPercentage = MaxWeightPercentage;
+	type UpdateQueueRatio = UpdateQueueRatio;
 	type SecondsPerBlock = SecondsPerBlock;
 	type WeightInfo = MockAutomationTimeWeight<Test>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -214,9 +214,6 @@ pub const EXISTENTIAL_DEPOSIT: Balance = DOLLAR / 10;
 /// We use at most 10% of the block weight running scheduled tasks during `on_initialize`.
 const SCHEDULED_TASKS_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 
-/// Out of block weight for scheduled tasks, we use at most 50% of the block weight for updating task queue.
-const UPDATE_QUEUE_RATIO: Perbill = Perbill::from_percent(50);
-
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.
 const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
@@ -727,7 +724,7 @@ parameter_types! {
 	pub const MaxScheduleSeconds: u64 = 7 * 24 * 6 * 60;
 	pub const MaxBlockWeight: Weight = MAXIMUM_BLOCK_WEIGHT;
 	pub const MaxWeightPercentage: Perbill = SCHEDULED_TASKS_INITIALIZE_RATIO;
-	pub const UpdateQueueRatio: Perbill = UPDATE_QUEUE_RATIO;
+	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
 	pub const SecondsPerBlock: u64 = MILLISECS_PER_BLOCK / 1000;
 	pub const ExecutionWeightFee: Balance = 12;
 }

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -176,8 +176,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("neumann"),
 	impl_name: create_runtime_str!("neumann"),
 	authoring_version: 1,
-	// TODO: (jzhou) revert back to 275 after testing migration
-	spec_version: 276,
+	spec_version: 275,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -214,6 +214,9 @@ pub const EXISTENTIAL_DEPOSIT: Balance = DOLLAR / 10;
 /// We use at most 10% of the block weight running scheduled tasks during `on_initialize`.
 const SCHEDULED_TASKS_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 
+/// Out of block weight for scheduled tasks, we use at most 50% of the block weight for updating task queue.
+const UPDATE_QUEUE_RATIO: Perbill = Perbill::from_percent(50);
+
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.
 const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
@@ -724,6 +727,7 @@ parameter_types! {
 	pub const MaxScheduleSeconds: u64 = 7 * 24 * 6 * 60;
 	pub const MaxBlockWeight: Weight = MAXIMUM_BLOCK_WEIGHT;
 	pub const MaxWeightPercentage: Perbill = SCHEDULED_TASKS_INITIALIZE_RATIO;
+	pub const UpdateQueueRatio: Perbill = UPDATE_QUEUE_RATIO;
 	pub const SecondsPerBlock: u64 = MILLISECS_PER_BLOCK / 1000;
 	pub const ExecutionWeightFee: Balance = 12;
 }
@@ -750,6 +754,7 @@ impl pallet_automation_time::Config for Runtime {
 	type MaxScheduleSeconds = MaxScheduleSeconds;
 	type MaxBlockWeight = MaxBlockWeight;
 	type MaxWeightPercentage = MaxWeightPercentage;
+	type UpdateQueueRatio = UpdateQueueRatio;
 	type SecondsPerBlock = SecondsPerBlock;
 	type WeightInfo = pallet_automation_time::weights::AutomationWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -176,7 +176,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("neumann"),
 	impl_name: create_runtime_str!("neumann"),
 	authoring_version: 1,
-	spec_version: 275,
+	// TODO: (jzhou) revert back to 275 after testing migration
+	spec_version: 276,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -214,9 +214,6 @@ pub const EXISTENTIAL_DEPOSIT: Balance = DOLLAR / 10;
 /// We use at most 10% of the block weight running scheduled tasks during `on_initialize`.
 const SCHEDULED_TASKS_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 
-/// Out of block weight for scheduled tasks, we use at most 50% of the block weight for updating task queue.
-const UPDATE_QUEUE_RATIO: Perbill = Perbill::from_percent(50);
-
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.
 const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
@@ -727,7 +724,7 @@ parameter_types! {
 	pub const MaxScheduleSeconds: u64 = 7 * 24 * 6 * 60;
 	pub const MaxBlockWeight: Weight = MAXIMUM_BLOCK_WEIGHT;
 	pub const MaxWeightPercentage: Perbill = SCHEDULED_TASKS_INITIALIZE_RATIO;
-	pub const UpdateQueueRatio: Perbill = UPDATE_QUEUE_RATIO;
+	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
 	pub const SecondsPerBlock: u64 = MILLISECS_PER_BLOCK / 1000;
 	pub const ExecutionWeightFee: Balance = 12;
 }

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -214,6 +214,9 @@ pub const EXISTENTIAL_DEPOSIT: Balance = DOLLAR / 10;
 /// We use at most 10% of the block weight running scheduled tasks during `on_initialize`.
 const SCHEDULED_TASKS_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 
+/// Out of block weight for scheduled tasks, we use at most 50% of the block weight for updating task queue.
+const UPDATE_QUEUE_RATIO: Perbill = Perbill::from_percent(50);
+
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers. This is
 /// used to limit the maximal weight of a single extrinsic.
 const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
@@ -724,6 +727,7 @@ parameter_types! {
 	pub const MaxScheduleSeconds: u64 = 7 * 24 * 6 * 60;
 	pub const MaxBlockWeight: Weight = MAXIMUM_BLOCK_WEIGHT;
 	pub const MaxWeightPercentage: Perbill = SCHEDULED_TASKS_INITIALIZE_RATIO;
+	pub const UpdateQueueRatio: Perbill = UPDATE_QUEUE_RATIO;
 	pub const SecondsPerBlock: u64 = MILLISECS_PER_BLOCK / 1000;
 	pub const ExecutionWeightFee: Balance = 12;
 }
@@ -751,6 +755,7 @@ impl pallet_automation_time::Config for Runtime {
 	type MaxScheduleSeconds = MaxScheduleSeconds;
 	type MaxBlockWeight = MaxBlockWeight;
 	type MaxWeightPercentage = MaxWeightPercentage;
+	type UpdateQueueRatio = UpdateQueueRatio;
 	type SecondsPerBlock = SecondsPerBlock;
 	type WeightInfo = pallet_automation_time::weights::AutomationWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;


### PR DESCRIPTION
Prior to this PR, we're assuming that the blockchain always has the same "last_time_slot". However, this is not true, since the missed queue has different behavior from the scheduled task queue. 

The scheduled queue is pretty straightforward. At each slot (every 60 seconds), it wants to shift all of the tasks in the current task queue (1 min windows only) to missed queue and then shifts all of the tasks that are scheduled for the current time slot into the task queue. 

Missed queue, on the other hand, should take action on EVERY block, not every slot (assumption for this PR is 12 sec/block). On EVERY block, we will want to check if the missed_time_slot has been caught back up to current_time_slot. The reason for this behavior is if chain stalls and comes back later. The "last_time_slot" for scheduled should be back up to date to allow for scheduled tasks to continue executing. However, the "last_missed_slot" will be very behind since all of the slots that have been stalled will need to have their tasks shifted into the missed queue. It may not be possible to shift all tasks into missed queue in a single block. Therefore, we may have to shift into the missed queue slowly over the course of time, which is achieved through this PR's introduction of a couple of things:
1. `UpdateQueueRatio` variable to limit the movement of tasks into missed queue to just 50% of the targeted automation-time execution block time. 
2. migration to split the current "last_time_slot" into 2 separate variables that are stored. Given this new logic, the "last_missed_slot" always lags the "last_time_slot" (for scheduled tasks) by 60 seconds. The `last_missed_slot` will be used to track which slot we're caught up to for missed tasks, should we not be able to fully catch up in 1 block.