### PR TITLE
Change vesting timestamps from 5th of month to 1st of month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [277] - 2022-03-14
+Note: Runtime-only release
 - Disable treasury burn in runtime
 - Split update queue behavior for missed and scheduled queues
-- Added Democracy pallet and Technical Committee
+- Added Democracy pallet and Technical Committee (#bump-tx-version)
+- Added Turing initial allocation & vesting for wallets
+- Change vesting from the 5th of the month to the 1st of the month
 
 ## [1.2.7] - 2022-03-10
 - Removed Quadratic funding pallet; can now be found [here](https://github.com/OAK-Foundation/quadratic-funding-pallet)

--- a/distribution/turing_vesting.json
+++ b/distribution/turing_vesting.json
@@ -1,6 +1,6 @@
 [
   [
-    1651777200,
+    1651431600,
     [
       ["6AWgGe7oZuvc8542mBGwJVs1FVZoQdNH68bsaNvhzSY2xjYN", 200000000000000000],
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
@@ -9,7 +9,7 @@
     ] 
   ],
   [
-    1654455600,
+    1654110000,
     [
       ["6AWgGe7oZuvc8542mBGwJVs1FVZoQdNH68bsaNvhzSY2xjYN", 200000000000000000],
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
@@ -18,7 +18,7 @@
     ]
   ],
   [
-    1657047600,
+    1656702000,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -26,7 +26,7 @@
     ]
   ],
   [
-    1659726000,
+    1659380400,
     [
       ["6BBGxHoTygiPF3GYvuUoZU9tivMZwdmkNFuQk3JjfDmGpbVC", 373333333333333333],
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
@@ -35,7 +35,7 @@
     ]
   ],
   [
-    1662404400,
+    1662058800,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -43,7 +43,7 @@
     ]
   ],
   [
-    1664996400,
+    1664650800,
     [
       ["6BbQeXLRZv1ZHU8wyuLtjoGL5c1XDYvtqKCbVELtUVog6MAJ", 200000000000000000],
       ["67xc5vHrKcCbBeP7ACDcgwfUcPSqc8pxGiyowRHPypTueU4d", 266666666666666666],
@@ -55,7 +55,7 @@
     ]
   ],
   [
-    1667674800,
+    1667329200,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -63,7 +63,7 @@
     ]
   ],
   [
-    1670270400,
+    1669924800,
     [
       ["6BBGxHoTygiPF3GYvuUoZU9tivMZwdmkNFuQk3JjfDmGpbVC", 373333333333333333],
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
@@ -72,7 +72,7 @@
     ]
   ],
   [
-    1672948800,
+    1672603200,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -80,7 +80,7 @@
     ]
   ],
   [
-    1675627200,
+    1675281600,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -88,7 +88,7 @@
     ]
   ],
   [
-    1678046400,
+    1677700800,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -96,7 +96,7 @@
     ]
   ],
   [
-    1680721200,
+    1680375600,
     [
       ["6BbQeXLRZv1ZHU8wyuLtjoGL5c1XDYvtqKCbVELtUVog6MAJ", 200000000000000000],
       ["67xc5vHrKcCbBeP7ACDcgwfUcPSqc8pxGiyowRHPypTueU4d", 266666666666666666],
@@ -108,7 +108,7 @@
     ]
   ],
   [
-    1683313200,
+    1682967600,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -116,7 +116,7 @@
     ]
   ],
   [
-    1685991600,
+    1685646000,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -124,7 +124,7 @@
     ]
   ],
   [
-    1688583600,
+    1688238000,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -132,7 +132,7 @@
     ]
   ],
   [
-    1691262000,
+    1690916400,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -140,7 +140,7 @@
     ]
   ],
   [
-    1693940400,
+    1693594800,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -148,7 +148,7 @@
     ]
   ],
   [
-    1696532400,
+    1696186800,
     [
       ["6BbQeXLRZv1ZHU8wyuLtjoGL5c1XDYvtqKCbVELtUVog6MAJ", 200000000000000000],
       ["67xc5vHrKcCbBeP7ACDcgwfUcPSqc8pxGiyowRHPypTueU4d", 266666666666666666],
@@ -160,7 +160,7 @@
     ]
   ],
   [
-    1699214400,
+    1698865200,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -168,7 +168,7 @@
     ]
   ],
   [
-    1701806400,
+    1701460800,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -176,7 +176,7 @@
     ]
   ],
   [
-    1704484800,
+    1704139200,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -184,7 +184,7 @@
     ]
   ],
   [
-    1707163200,
+    1706817600,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -192,7 +192,7 @@
     ]
   ],
   [
-    1709668800,
+    1709323200,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -200,7 +200,7 @@
     ]
   ],
   [
-    1712343600,
+    1711998000,
     [
       ["6BbQeXLRZv1ZHU8wyuLtjoGL5c1XDYvtqKCbVELtUVog6MAJ", 200000000000000000],
       ["67xc5vHrKcCbBeP7ACDcgwfUcPSqc8pxGiyowRHPypTueU4d", 266666666666666666],
@@ -211,7 +211,7 @@
     ]
   ],
   [
-    1714935600,
+    1714590000,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -219,7 +219,7 @@
     ]
   ],
   [
-    1717614000,
+    1717268400,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -227,7 +227,7 @@
     ]
   ],
   [
-    1720206000,
+    1719860400,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -235,7 +235,7 @@
     ]
   ],
   [
-    1722884400,
+    1722538800,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -243,7 +243,7 @@
     ]
   ],
   [
-    1725562800,
+    1725217200,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -251,7 +251,7 @@
     ]
   ],
   [
-    1728154800,
+    1727809200,
     [
       ["67xc5vHrKcCbBeP7ACDcgwfUcPSqc8pxGiyowRHPypTueU4d", 266666666666666666],
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
@@ -260,7 +260,7 @@
     ]
   ],
   [
-    1730836800,
+    1730487600,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -268,7 +268,7 @@
     ]
   ],
   [
-    1733428800,
+    1733083200,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -276,7 +276,7 @@
     ]
   ],
   [
-    1736107200,
+    1735761600,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -284,7 +284,7 @@
     ]
   ],
   [
-    1738785600,
+    1738440000,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -292,7 +292,7 @@
     ]
   ],
   [
-    1741204800,
+    1740859200,
     [
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],
       ["66fiEgBVzAGs75UEqwGyXnJBbvujb9NwbvrXbvoqWYbK6Uui", 41666666666666666],
@@ -300,7 +300,7 @@
     ]
   ],
   [
-    1743879600,
+    1743534000,
     [
       ["67xc5vHrKcCbBeP7ACDcgwfUcPSqc8pxGiyowRHPypTueU4d", 266666666666666666],
       ["68UQrHt7FQ171AF5nvkUV2jChxhJv58tp8xXZ6spzMnvWvFN", 41666666666666666],

--- a/node/src/chain_spec/turing.rs
+++ b/node/src/chain_spec/turing.rs
@@ -122,8 +122,8 @@ pub fn turing_staging() -> ChainSpec {
 				serde_json::from_slice(vesting_json).unwrap();
 
 			let vested_tokens = 9_419_999_999_999_999_919;
-			let vest_starting_time: u64 = 1651777200;
-			let vest_ending_time: u64 = 1743879600;
+			let vest_starting_time: u64 = 1651431600;
+			let vest_ending_time: u64 = 1743534000;
 			validate_vesting(initial_vesting.clone(), vested_tokens, EXISTENTIAL_DEPOSIT, vest_starting_time, vest_ending_time);
 
 			let collator_bond = 400_000 * DOLLAR;
@@ -223,8 +223,8 @@ pub fn turing_live() -> ChainSpec {
 				serde_json::from_slice(vesting_json).unwrap();
 
 			let vested_tokens = 9_419_999_999_999_999_919;
-			let vest_starting_time: u64 = 1651777200;
-			let vest_ending_time: u64 = 1743879600;
+			let vest_starting_time: u64 = 1651431600;
+			let vest_ending_time: u64 = 1743534000;
 			validate_vesting(initial_vesting.clone(), vested_tokens, EXISTENTIAL_DEPOSIT, vest_starting_time, vest_ending_time);
 
 			let collator_bond = 400_000 * DOLLAR;
@@ -371,8 +371,8 @@ mod tests {
 			serde_json::from_slice(vesting_json).unwrap();
 
 		let vested_tokens = 9_419_999_999_999_999_919;
-		let vest_starting_time: u64 = 1651777200;
-		let vest_ending_time: u64 = 1743879600;
+		let vest_starting_time: u64 = 1651431600;
+		let vest_ending_time: u64 = 1743534000;
 		validate_vesting(initial_vesting, vested_tokens, EXISTENTIAL_DEPOSIT, vest_starting_time, vest_ending_time);
 	}
 


### PR DESCRIPTION
After confirmation and more clarity on when lease 20 block production starts, we are moving the vesting from 5th of the month to the 1st of the month to provide time to send allocations to the appropriate wallets.

https://kusama.subscan.io/block/12096000
Next vesting after initial block produciton is 5/1 and we have to distribute to each token by the 4th of each month.