### PR TITLE
split update queue behavior for missed and scheduled queues (#101)

### DIFF
--- a/pallets/automation-time/src/migrations.rs
+++ b/pallets/automation-time/src/migrations.rs
@@ -1,0 +1,28 @@
+use crate::{Config, Weight};
+use frame_support::traits::Get;
+use log::info;
+
+pub mod v1 {
+	use frame_support::{migration::get_storage_value, traits::StorageVersion};
+
+  use crate::{LastTimeSlot, Pallet};
+
+use super::*;
+
+	pub fn migrate<T: Config>() -> Weight {
+		info!(target: "automation-time", "Migrating automation-time v1");
+    let pallet_prefix: &[u8] = b"AutomationTime";
+		let storage_item_prefix: &[u8] = b"LastTimeSlot";
+
+		let stored_data = get_storage_value::<u64>(
+			pallet_prefix,
+			storage_item_prefix,
+      &[],
+		).expect("Must have last slot value");
+
+    LastTimeSlot::<T>::put((stored_data, stored_data));
+    info!(target: "automation-time", "Completed automation-time migration to v1");
+    StorageVersion::new(1).put::<Pallet<T>>();
+    T::DbWeight::get().reads_writes(1, 1)
+	}
+}

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -118,8 +118,9 @@ impl pallet_timestamp::Config for Test {
 parameter_types! {
 	pub const MaxTasksPerSlot: u32 = 2;
 	pub const MaxScheduleSeconds: u64 = 1 * 24 * 60 * 60;
-	pub const MaxBlockWeight: Weight = 900_000;
+	pub const MaxBlockWeight: Weight = 1_000_000;
 	pub const MaxWeightPercentage: Perbill = Perbill::from_percent(10);
+	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
 	pub const SecondsPerBlock: u64 = 12;
 	pub const ExecutionWeightFee: Balance = 12;
 }
@@ -177,13 +178,13 @@ impl<Test: frame_system::Config> pallet_automation_time::WeightInfo for MockWeig
 	fn update_task_queue_overhead() -> Weight {
 		10_000
 	}
-	fn update_task_queue_max_current() -> Weight {
-		20_000
-	}
 	fn append_to_missed_tasks(v: u32, ) -> Weight {
 		(20_000 * v).into()
 	}
-	fn update_task_queue_max_current_and_next() -> Weight {
+	fn update_scheduled_task_queue() -> Weight {
+		20_000
+	}
+	fn shift_missed_tasks() -> Weight {
 		20_000
 	}
 }
@@ -202,6 +203,7 @@ impl pallet_automation_time::Config for Test {
 	type MaxScheduleSeconds = MaxScheduleSeconds;
 	type MaxBlockWeight = MaxBlockWeight;
 	type MaxWeightPercentage = MaxWeightPercentage;
+	type UpdateQueueRatio = UpdateQueueRatio;
 	type SecondsPerBlock = SecondsPerBlock;
 	type WeightInfo = MockWeight<Test>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/pallets/automation-time/src/weights.rs
+++ b/pallets/automation-time/src/weights.rs
@@ -50,9 +50,9 @@ pub trait WeightInfo {
 	fn run_tasks_many_found(v: u32, ) -> Weight;
 	fn run_tasks_many_missing(v: u32, ) -> Weight;
 	fn update_task_queue_overhead() -> Weight;
-	fn update_task_queue_max_current() -> Weight;
 	fn append_to_missed_tasks(v: u32, ) -> Weight;
-	fn update_task_queue_max_current_and_next() -> Weight;
+	fn update_scheduled_task_queue() -> Weight;
+	fn shift_missed_tasks() -> Weight;
 }
 
 /// Weight functions for `pallet_automation_time`.
@@ -63,7 +63,7 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
 	fn schedule_notify_task_empty() -> Weight {
-		(37_000_000 as Weight)
+		(38_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
@@ -126,7 +126,7 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
 	fn force_cancel_scheduled_task_full() -> Weight {
-		(30_000_000 as Weight)
+		(29_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
@@ -134,7 +134,7 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime ScheduledTasks (r:1 w:0)
 	// Storage: AutomationTime TaskQueue (r:1 w:1)
 	fn force_cancel_overflow_task() -> Weight {
-		(30_000_000 as Weight)
+		(29_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
@@ -150,32 +150,32 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	fn run_missed_tasks_many_found(v: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 89_000
-			.saturating_add((10_437_000 as Weight).saturating_mul(v as Weight))
+			// Standard Error: 59_000
+			.saturating_add((10_875_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(v as Weight)))
 	}
 	// Storage: AutomationTime Tasks (r:1 w:0)
 	fn run_missed_tasks_many_missing(v: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 59_000
-			.saturating_add((8_875_000 as Weight).saturating_mul(v as Weight))
+			// Standard Error: 0
+			.saturating_add((9_000_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
 	}
 	// Storage: AutomationTime Tasks (r:1 w:1)
 	// Storage: System Account (r:2 w:2)
 	fn run_tasks_many_found(v: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 0
-			.saturating_add((29_000_000 as Weight).saturating_mul(v as Weight))
+			// Standard Error: 62_000
+			.saturating_add((29_937_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().reads((3 as Weight).saturating_mul(v as Weight)))
 			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(v as Weight)))
 	}
 	// Storage: AutomationTime Tasks (r:1 w:0)
 	fn run_tasks_many_missing(v: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 70_000
-			.saturating_add((8_812_000 as Weight).saturating_mul(v as Weight))
+			// Standard Error: 0
+			.saturating_add((9_000_000 as Weight).saturating_mul(v as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
 	}
 	// Storage: Timestamp Now (r:1 w:0)
@@ -183,29 +183,29 @@ impl<T: frame_system::Config> WeightInfo for AutomationWeight<T> {
 		(1_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 	}
-	// Storage: Timestamp Now (r:1 w:0)
-	// Storage: AutomationTime LastTimeSlot (r:1 w:1)
-	fn update_task_queue_max_current() -> Weight {
-		(4_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
-	}
+	// Storage: AutomationTime MissedQueue (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
 	fn append_to_missed_tasks(v: u32, ) -> Weight {
-		(219_000 as Weight)
-			// Standard Error: 59_000
-			.saturating_add((2_625_000 as Weight).saturating_mul(v as Weight))
+		(1_365_000 as Weight)
+			// Standard Error: 115_000
+			.saturating_add((2_000_000 as Weight).saturating_mul(v as Weight))
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(v as Weight)))
 	}
-	// Storage: Timestamp Now (r:1 w:0)
-	// Storage: AutomationTime LastTimeSlot (r:1 w:1)
 	// Storage: AutomationTime TaskQueue (r:1 w:1)
 	// Storage: AutomationTime MissedQueue (r:1 w:1)
 	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
-	fn update_task_queue_max_current_and_next() -> Weight {
-		(26_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+	fn update_scheduled_task_queue() -> Weight {
+		(22_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
+	}
+	// Storage: AutomationTime ScheduledTasks (r:1 w:1)
+	fn shift_missed_tasks() -> Weight {
+		(3_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 }

--- a/pallets/valve/src/mock.rs
+++ b/pallets/valve/src/mock.rs
@@ -121,6 +121,7 @@ parameter_types! {
 	pub const MaxScheduleSeconds: u64 = 1 * 24 * 60 * 60;
 	pub const MaxBlockWeight: Weight = 1200_000;
 	pub const MaxWeightPercentage: Perbill = Perbill::from_percent(10);
+	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
 	pub const SecondsPerBlock: u64 = 12;
 	pub const ExecutionWeightFee: Balance = 12;
 }
@@ -180,13 +181,13 @@ impl<Test: frame_system::Config> pallet_automation_time::WeightInfo
 	fn update_task_queue_overhead() -> Weight {
 		0
 	}
-	fn update_task_queue_max_current() -> Weight {
-		0
-	}
 	fn append_to_missed_tasks(v: u32, ) -> Weight {
 		0
 	}
-	fn update_task_queue_max_current_and_next() -> Weight {
+	fn update_scheduled_task_queue() -> Weight {
+		0
+	}
+	fn shift_missed_tasks() -> Weight {
 		0
 	}
 }
@@ -205,6 +206,7 @@ impl pallet_automation_time::Config for Test {
 	type MaxScheduleSeconds = MaxScheduleSeconds;
 	type MaxBlockWeight = MaxBlockWeight;
 	type MaxWeightPercentage = MaxWeightPercentage;
+	type UpdateQueueRatio = UpdateQueueRatio;
 	type SecondsPerBlock = SecondsPerBlock;
 	type WeightInfo = MockAutomationTimeWeight<Test>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -724,6 +724,7 @@ parameter_types! {
 	pub const MaxScheduleSeconds: u64 = 7 * 24 * 6 * 60;
 	pub const MaxBlockWeight: Weight = MAXIMUM_BLOCK_WEIGHT;
 	pub const MaxWeightPercentage: Perbill = SCHEDULED_TASKS_INITIALIZE_RATIO;
+	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
 	pub const SecondsPerBlock: u64 = MILLISECS_PER_BLOCK / 1000;
 	pub const ExecutionWeightFee: Balance = 12;
 }
@@ -750,6 +751,7 @@ impl pallet_automation_time::Config for Runtime {
 	type MaxScheduleSeconds = MaxScheduleSeconds;
 	type MaxBlockWeight = MaxBlockWeight;
 	type MaxWeightPercentage = MaxWeightPercentage;
+	type UpdateQueueRatio = UpdateQueueRatio;
 	type SecondsPerBlock = SecondsPerBlock;
 	type WeightInfo = pallet_automation_time::weights::AutomationWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -724,6 +724,7 @@ parameter_types! {
 	pub const MaxScheduleSeconds: u64 = 7 * 24 * 6 * 60;
 	pub const MaxBlockWeight: Weight = MAXIMUM_BLOCK_WEIGHT;
 	pub const MaxWeightPercentage: Perbill = SCHEDULED_TASKS_INITIALIZE_RATIO;
+	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
 	pub const SecondsPerBlock: u64 = MILLISECS_PER_BLOCK / 1000;
 	pub const ExecutionWeightFee: Balance = 12;
 }
@@ -751,6 +752,7 @@ impl pallet_automation_time::Config for Runtime {
 	type MaxScheduleSeconds = MaxScheduleSeconds;
 	type MaxBlockWeight = MaxBlockWeight;
 	type MaxWeightPercentage = MaxWeightPercentage;
+	type UpdateQueueRatio = UpdateQueueRatio;
 	type SecondsPerBlock = SecondsPerBlock;
 	type WeightInfo = pallet_automation_time::weights::AutomationWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;


### PR DESCRIPTION
* logic changes for updating task queue

* migration testing

* wip: for testing

* adjust storage version and fix update task queue logic

* remove broken storage, input using correct storage

* fix logs and comments and spec version

* CR comments

Co-authored-by: Justin Zhou <justinzhou@macbook-pro.myfiosgateway.com>