### PR TITLE
Use parachain-staking for collator selection, delegation, and inflation-based payouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6289,7 +6289,7 @@ dependencies = [
 [[package]]
 name = "parachain-staking"
 version = "3.0.0"
-source = "git+https://github.com/OAK-Foundation/moonbeam?branch=oak-polkadot-v0.9.18#20f66646363054e0dd11d9f30e3a0049e4800db8"
+source = "git+https://github.com/OAK-Foundation/moonbeam?branch=oak-polkadot-v0.9.18#4b6cb69127f5ff57c1b0d733a454f7520e585206"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11554,7 +11554,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array 0.14.5",
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -2822,7 +2822,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -2831,7 +2831,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
- "typenum",
+ "typenum 1.15.0",
  "version_check",
 ]
 
@@ -4487,7 +4487,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -4963,7 +4963,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_distr",
  "simba",
- "typenum",
+ "typenum 1.15.0",
 ]
 
 [[package]]
@@ -5023,7 +5023,6 @@ dependencies = [
  "pallet-automation-time-rpc-runtime-api",
  "pallet-balances",
  "pallet-bounties",
- "pallet-collator-selection",
  "pallet-collective",
  "pallet-democracy",
  "pallet-membership",
@@ -5039,6 +5038,7 @@ dependencies = [
  "pallet-vesting 1.0.0",
  "pallet-xcm",
  "parachain-info",
+ "parachain-staking",
  "parity-scale-codec",
  "polkadot-parachain",
  "polkadot-runtime-common",
@@ -5205,6 +5205,7 @@ dependencies = [
  "neumann-runtime",
  "pallet-automation-time-rpc",
  "pallet-transaction-payment-rpc",
+ "parachain-staking",
  "parity-scale-codec",
  "polkadot-cli",
  "polkadot-parachain",
@@ -6303,6 +6304,26 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+]
+
+[[package]]
+name = "parachain-staking"
+version = "3.0.0"
+source = "git+https://github.com/OAK-Foundation/moonbeam?branch=oak-polkadot-v0.9.18#20f66646363054e0dd11d9f30e3a0049e4800db8"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+ "substrate-fixed",
 ]
 
 [[package]]
@@ -10908,6 +10929,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-fixed"
+version = "0.5.9"
+source = "git+https://github.com/encointer/substrate-fixed#a4fb461aae6205ffc55bed51254a40c52be04e5d"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "typenum 1.16.0",
+]
+
+[[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.18#fc3fd073d3a0acf9933c3994b660ebd7b5833f65"
@@ -11554,6 +11585,15 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "git+https://github.com/encointer/typenum?tag=v1.16.0#4c8dddaa8bdd13130149e43b4085ad14e960617f"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+]
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5603,26 +5603,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-collator-selection"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.18#b1e91afb7421309b203d7627b736d9bcf58260eb"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log",
- "pallet-authorship",
- "pallet-session",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "sp-runtime",
- "sp-staking",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.18#fc3fd073d3a0acf9933c3994b660ebd7b5833f65"
@@ -11527,7 +11507,6 @@ dependencies = [
  "pallet-automation-time-rpc-runtime-api",
  "pallet-balances",
  "pallet-bounties",
- "pallet-collator-selection",
  "pallet-collective",
  "pallet-democracy",
  "pallet-membership",
@@ -11543,6 +11522,7 @@ dependencies = [
  "pallet-vesting 1.0.0",
  "pallet-xcm",
  "parachain-info",
+ "parachain-staking",
  "parity-scale-codec",
  "polkadot-parachain",
  "polkadot-runtime-common",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -111,5 +111,4 @@ polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "r
 polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.18" }
 
 # Moonbeam Dependencies
-# TODO: change branch to oak-polkadot-v0.19.8 before merging
-parachain-staking = { git = "https://github.com/OAK-Foundation/moonbeam", default-features = false, branch = "nikhil/oak-polkadot-v0.9.18" }
+parachain-staking = { git = "https://github.com/OAK-Foundation/moonbeam", default-features = false, branch = "oak-polkadot-v0.9.18" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -109,3 +109,6 @@ polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = 
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.18" }
 polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.18" }
 polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.18" }
+
+# Moonbeam Dependencies
+parachain-staking = { path = "../../moonbeam/pallets/parachain-staking", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -111,4 +111,5 @@ polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "r
 polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.18" }
 
 # Moonbeam Dependencies
-parachain-staking = { path = "../../moonbeam/pallets/parachain-staking", default-features = false }
+# TODO: change branch to oak-polkadot-v0.19.8 before merging
+parachain-staking = { git = "https://github.com/OAK-Foundation/moonbeam", default-features = false, branch = "nikhil/oak-polkadot-v0.9.18" }

--- a/node/src/chain_spec/neumann.rs
+++ b/node/src/chain_spec/neumann.rs
@@ -376,8 +376,6 @@ fn testnet_genesis(
 		},
 		balances: neumann_runtime::BalancesConfig { balances: endowed_accounts },
 		parachain_info: neumann_runtime::ParachainInfoConfig { parachain_id: para_id },
-		// Defaults to active collators from session pallet unless configured otherwise
-		parachain_staking: Default::default(),
 		session: neumann_runtime::SessionConfig {
 			keys: invulnerables
 				.into_iter()
@@ -390,6 +388,8 @@ fn testnet_genesis(
 				})
 				.collect(),
 		},
+		// Defaults to active collators from session pallet unless configured otherwise
+		parachain_staking: Default::default(),
 		// no need to pass anything to aura, in fact it will panic if we do. Session will take care
 		// of this.
 		aura: Default::default(),

--- a/node/src/chain_spec/neumann.rs
+++ b/node/src/chain_spec/neumann.rs
@@ -376,9 +376,9 @@ pub fn neumann_inflation_config() -> InflationInfo<Balance> {
 	InflationInfo {
 		// staking expectations
 		expect: Range {
-			min: 100_000 * 1_000_000_000_000_000_000,
-			ideal: 200_000 * 1_000_000_000_000_000_000,
-			max: 500_000 * 1_000_000_000_000_000_000,
+			min: 4_000_000 * DOLLAR,
+			ideal: 6_000_000 * DOLLAR,
+			max: 8_000_000 * DOLLAR,
 		},
 		annual,
 		round: to_round_inflation(annual),

--- a/node/src/chain_spec/neumann.rs
+++ b/node/src/chain_spec/neumann.rs
@@ -11,8 +11,8 @@ use crate::chain_spec::{
 	Extensions,
 };
 use neumann_runtime::{
-	CouncilConfig, MinCollatorStk, SudoConfig, TechnicalMembershipConfig, ValveConfig,
-	VestingConfig, DOLLAR, EXISTENTIAL_DEPOSIT, TOKEN_DECIMALS,
+	CouncilConfig, SudoConfig, TechnicalMembershipConfig, ValveConfig, VestingConfig, DOLLAR,
+	EXISTENTIAL_DEPOSIT, TOKEN_DECIMALS,
 };
 use parachain_staking::{inflation, InflationInfo, Range};
 use primitives::{AccountId, AuraId, Balance};
@@ -61,8 +61,6 @@ pub fn development_config() -> ChainSpec {
 			let endowed_accounts: Vec<(AccountId, Balance)> =
 				accounts.iter().cloned().map(|k| (k, initial_balance)).collect();
 
-			let collator_bond = MinCollatorStk::get();
-
 			testnet_genesis(
 				// initial collators.
 				vec![
@@ -82,7 +80,6 @@ pub fn development_config() -> ChainSpec {
 				vec![],
 				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
 				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
-				collator_bond,
 			)
 		},
 		Vec::new(),
@@ -129,8 +126,6 @@ pub fn local_testnet_config() -> ChainSpec {
 			let initial_vesting: Vec<(u64, Vec<(AccountId, Balance)>)> =
 				serde_json::from_slice(vesting_json).unwrap();
 
-			let collator_bond = MinCollatorStk::get();
-
 			testnet_genesis(
 				// initial collators.
 				vec![
@@ -150,7 +145,6 @@ pub fn local_testnet_config() -> ChainSpec {
 				initial_vesting,
 				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
 				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
-				collator_bond,
 			)
 		},
 		// Bootnodes
@@ -211,8 +205,6 @@ pub fn neumann_staging_testnet_config() -> ChainSpec {
 				vest_ending_time,
 			);
 
-			let collator_bond = MinCollatorStk::get();
-
 			testnet_genesis(
 				// initial collators.
 				vec![
@@ -259,7 +251,6 @@ pub fn neumann_staging_testnet_config() -> ChainSpec {
 					// 669ocRxey7vxUJs1TTRWe31zwrpGr8B13zRfAHB6yhhfcMud
 					hex!["001fbcefa8c96f3d2e236688da5485a0af67988b78d61ea952f461255d1f4267"].into(),
 				],
-				collator_bond,
 			)
 		},
 		// Bootnodes
@@ -303,8 +294,6 @@ pub fn neumann_latest() -> ChainSpec {
 				ALLOC_TOKENS_TOTAL,
 				EXISTENTIAL_DEPOSIT,
 			);
-
-			let collator_bond = MinCollatorStk::get();
 
 			testnet_genesis(
 				// initial collators.
@@ -352,7 +341,6 @@ pub fn neumann_latest() -> ChainSpec {
 					// 669ocRxey7vxUJs1TTRWe31zwrpGr8B13zRfAHB6yhhfcMud
 					hex!["001fbcefa8c96f3d2e236688da5485a0af67988b78d61ea952f461255d1f4267"].into(),
 				],
-				collator_bond,
 			)
 		},
 		// Bootnodes
@@ -406,7 +394,6 @@ fn testnet_genesis(
 	vesting_schedule: Vec<(u64, Vec<(AccountId, Balance)>)>,
 	general_councils: Vec<AccountId>,
 	technical_memberships: Vec<AccountId>,
-	collator_bond: u128,
 ) -> neumann_runtime::GenesisConfig {
 	neumann_runtime::GenesisConfig {
 		system: neumann_runtime::SystemConfig {
@@ -417,11 +404,7 @@ fn testnet_genesis(
 		balances: neumann_runtime::BalancesConfig { balances: endowed_accounts },
 		parachain_info: neumann_runtime::ParachainInfoConfig { parachain_id: para_id },
 		parachain_staking: neumann_runtime::ParachainStakingConfig {
-			candidates: invulnerables
-				.iter()
-				.cloned()
-				.map(|(acc, _)| (acc, collator_bond))
-				.collect(),
+			candidates: vec![],
 			delegations: vec![],
 			inflation_config: neumann_inflation_config(),
 		},

--- a/node/src/chain_spec/neumann.rs
+++ b/node/src/chain_spec/neumann.rs
@@ -11,8 +11,8 @@ use crate::chain_spec::{
 	Extensions,
 };
 use neumann_runtime::{
-	CouncilConfig, SudoConfig, TechnicalMembershipConfig, ValveConfig, VestingConfig, DOLLAR,
-	EXISTENTIAL_DEPOSIT, TOKEN_DECIMALS,
+	CouncilConfig, MinCollatorStk, SudoConfig, TechnicalMembershipConfig, ValveConfig,
+	VestingConfig, DOLLAR, EXISTENTIAL_DEPOSIT, TOKEN_DECIMALS,
 };
 use parachain_staking::{inflation, InflationInfo, Range};
 use primitives::{AccountId, AuraId, Balance};
@@ -61,7 +61,7 @@ pub fn development_config() -> ChainSpec {
 			let endowed_accounts: Vec<(AccountId, Balance)> =
 				accounts.iter().cloned().map(|k| (k, initial_balance)).collect();
 
-			let collator_bond = EXISTENTIAL_DEPOSIT * 16;
+			let collator_bond = MinCollatorStk::get();
 
 			testnet_genesis(
 				// initial collators.
@@ -129,7 +129,7 @@ pub fn local_testnet_config() -> ChainSpec {
 			let initial_vesting: Vec<(u64, Vec<(AccountId, Balance)>)> =
 				serde_json::from_slice(vesting_json).unwrap();
 
-			let collator_bond = EXISTENTIAL_DEPOSIT * 16;
+			let collator_bond = MinCollatorStk::get();
 
 			testnet_genesis(
 				// initial collators.
@@ -211,7 +211,7 @@ pub fn neumann_staging_testnet_config() -> ChainSpec {
 				vest_ending_time,
 			);
 
-			let collator_bond = EXISTENTIAL_DEPOSIT * 16;
+			let collator_bond = MinCollatorStk::get();
 
 			testnet_genesis(
 				// initial collators.
@@ -304,7 +304,7 @@ pub fn neumann_latest() -> ChainSpec {
 				EXISTENTIAL_DEPOSIT,
 			);
 
-			let collator_bond = EXISTENTIAL_DEPOSIT * 16;
+			let collator_bond = MinCollatorStk::get();
 
 			testnet_genesis(
 				// initial collators.

--- a/node/src/chain_spec/neumann.rs
+++ b/node/src/chain_spec/neumann.rs
@@ -14,9 +14,7 @@ use neumann_runtime::{
 	CouncilConfig, SudoConfig, TechnicalMembershipConfig, ValveConfig, VestingConfig, DOLLAR,
 	EXISTENTIAL_DEPOSIT, TOKEN_DECIMALS,
 };
-use parachain_staking::{inflation, InflationInfo, Range};
 use primitives::{AccountId, AuraId, Balance};
-use sp_runtime::Perbill;
 
 static TOKEN_SYMBOL: &str = "NEU";
 const SS_58_FORMAT: u32 = 51;
@@ -360,31 +358,6 @@ pub fn neumann_latest() -> ChainSpec {
 	)
 }
 
-pub fn neumann_inflation_config() -> InflationInfo<Balance> {
-	fn to_round_inflation(annual: Range<Perbill>) -> Range<Perbill> {
-		inflation::perbill_annual_to_perbill_round(
-			annual,
-			// rounds per year
-			inflation::BLOCKS_PER_YEAR / neumann_runtime::DefaultBlocksPerRound::get(),
-		)
-	}
-	let annual = Range {
-		min: Perbill::from_percent(4),
-		ideal: Perbill::from_percent(5),
-		max: Perbill::from_percent(5),
-	};
-	InflationInfo {
-		// staking expectations
-		expect: Range {
-			min: 4_000_000 * DOLLAR,
-			ideal: 6_000_000 * DOLLAR,
-			max: 8_000_000 * DOLLAR,
-		},
-		annual,
-		round: to_round_inflation(annual),
-	}
-}
-
 fn testnet_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
 	root_key: AccountId,
@@ -403,11 +376,8 @@ fn testnet_genesis(
 		},
 		balances: neumann_runtime::BalancesConfig { balances: endowed_accounts },
 		parachain_info: neumann_runtime::ParachainInfoConfig { parachain_id: para_id },
-		parachain_staking: neumann_runtime::ParachainStakingConfig {
-			candidates: vec![],
-			delegations: vec![],
-			inflation_config: neumann_inflation_config(),
-		},
+		// Defaults to active collators from session pallet unless configured otherwise
+		parachain_staking: Default::default(),
 		session: neumann_runtime::SessionConfig {
 			keys: invulnerables
 				.into_iter()

--- a/node/src/chain_spec/turing.rs
+++ b/node/src/chain_spec/turing.rs
@@ -7,8 +7,8 @@ use sp_core::{crypto::UncheckedInto, sr25519};
 
 use super::TELEMETRY_URL;
 use crate::chain_spec::{
-	get_account_id_from_seed, get_collator_keys_from_seed, validate_allocation,
-	validate_vesting, Extensions,
+	get_account_id_from_seed, get_collator_keys_from_seed, validate_allocation, validate_vesting,
+	Extensions,
 };
 use primitives::{AccountId, AuraId, Balance};
 use turing_runtime::{
@@ -60,8 +60,6 @@ pub fn turing_development_config() -> ChainSpec {
 			let endowed_accounts: Vec<(AccountId, Balance)> =
 				accounts.iter().cloned().map(|k| (k, initial_balance)).collect();
 
-			let collator_bond = EXISTENTIAL_DEPOSIT * 16;
-
 			testnet_genesis(
 				// initial collators.
 				vec![
@@ -81,7 +79,6 @@ pub fn turing_development_config() -> ChainSpec {
 				vec![],
 				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
 				vec![get_account_id_from_seed::<sr25519::Public>("Alice")],
-				collator_bond,
 			)
 		},
 		Vec::new(),
@@ -135,8 +132,6 @@ pub fn turing_staging() -> ChainSpec {
 				vest_ending_time,
 			);
 
-			let collator_bond = 400_000 * DOLLAR;
-
 			testnet_genesis(
 				// initial collators.
 				vec![
@@ -185,7 +180,6 @@ pub fn turing_staging() -> ChainSpec {
 					// 669ocRxey7vxUJs1TTRWe31zwrpGr8B13zRfAHB6yhhfcMud
 					hex!["001fbcefa8c96f3d2e236688da5485a0af67988b78d61ea952f461255d1f4267"].into(),
 				],
-				collator_bond,
 			)
 		},
 		// Bootnodes
@@ -246,8 +240,6 @@ pub fn turing_live() -> ChainSpec {
 				vest_ending_time,
 			);
 
-			let collator_bond = 400_000 * DOLLAR;
-
 			testnet_genesis(
 				// initial collators.
 				vec![
@@ -296,7 +288,6 @@ pub fn turing_live() -> ChainSpec {
 					// 669ocRxey7vxUJs1TTRWe31zwrpGr8B13zRfAHB6yhhfcMud
 					hex!["001fbcefa8c96f3d2e236688da5485a0af67988b78d61ea952f461255d1f4267"].into(),
 				],
-				collator_bond,
 			)
 		},
 		// Bootnodes
@@ -325,7 +316,6 @@ fn testnet_genesis(
 	vesting_schedule: Vec<(u64, Vec<(AccountId, Balance)>)>,
 	general_councils: Vec<AccountId>,
 	technical_memberships: Vec<AccountId>,
-	collator_bond: u128,
 ) -> turing_runtime::GenesisConfig {
 	turing_runtime::GenesisConfig {
 		system: turing_runtime::SystemConfig {
@@ -335,11 +325,6 @@ fn testnet_genesis(
 		},
 		balances: turing_runtime::BalancesConfig { balances: endowed_accounts },
 		parachain_info: turing_runtime::ParachainInfoConfig { parachain_id: para_id },
-		collator_selection: turing_runtime::CollatorSelectionConfig {
-			invulnerables: invulnerables.iter().cloned().map(|(acc, _)| acc).collect(),
-			candidacy_bond: collator_bond,
-			..Default::default()
-		},
 		session: turing_runtime::SessionConfig {
 			keys: invulnerables
 				.into_iter()
@@ -352,6 +337,8 @@ fn testnet_genesis(
 				})
 				.collect(),
 		},
+		// Defaults to active collators from session pallet unless configured otherwise
+		parachain_staking: Default::default(),
 		// no need to pass anything to aura, in fact it will panic if we do. Session will take care
 		// of this.
 		aura: Default::default(),

--- a/runtime/neumann/Cargo.toml
+++ b/runtime/neumann/Cargo.toml
@@ -78,7 +78,6 @@ cumulus-pallet-xcmp-queue = { git = 'https://github.com/paritytech/cumulus', bra
 cumulus-primitives-core = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.18', default-features = false }
 cumulus-primitives-timestamp = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.18', default-features = false }
 cumulus-primitives-utility = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.18', default-features = false }
-pallet-collator-selection = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.18', default-features = false }
 parachain-info = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.18', default-features = false }
 
 # Polkadot Dependencies
@@ -123,7 +122,6 @@ std = [
 	"pallet-automation-time-rpc-runtime-api/std",
 	"pallet-balances/std",
 	"pallet-bounties/std",
-	"pallet-collator-selection/std",
 	"pallet-collective/std",
 	"pallet-democracy/std",
 	"pallet-membership/std",
@@ -165,7 +163,6 @@ runtime-benchmarks = [
 	"pallet-automation-time/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-bounties/runtime-benchmarks",
-	"pallet-collator-selection/runtime-benchmarks",
 	"pallet-collective/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",

--- a/runtime/neumann/Cargo.toml
+++ b/runtime/neumann/Cargo.toml
@@ -89,6 +89,9 @@ xcm = { git = "https://github.com/paritytech/polkadot", default-features = false
 xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.18" }
 xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.18" }
 
+# Moonbeam Dependencies
+parachain-staking = { path = "../../../moonbeam/pallets/parachain-staking", default-features = false }
+
 [features]
 default = [
 	"std",
@@ -134,6 +137,7 @@ std = [
 	"pallet-transaction-payment/std",
 	"pallet-valve/std",
 	"pallet-vesting/std",
+	"parachain-staking/std",
 	"primitives/std",
 	"cumulus-pallet-aura-ext/std",
 	"cumulus-pallet-parachain-system/std",
@@ -168,4 +172,5 @@ runtime-benchmarks = [
 	"pallet-valve/runtime-benchmarks",
 	"pallet-vesting/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
+	"parachain-staking/runtime-benchmarks",
 ]

--- a/runtime/neumann/Cargo.toml
+++ b/runtime/neumann/Cargo.toml
@@ -89,7 +89,8 @@ xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features
 xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.18" }
 
 # Moonbeam Dependencies
-parachain-staking = { path = "../../../moonbeam/pallets/parachain-staking", default-features = false }
+# TODO: change branch to oak-polkadot-v0.19.8 before merging
+parachain-staking = { git = "https://github.com/OAK-Foundation/moonbeam", default-features = false, branch = "nikhil/oak-polkadot-v0.9.18" }
 
 [features]
 default = [

--- a/runtime/neumann/Cargo.toml
+++ b/runtime/neumann/Cargo.toml
@@ -89,8 +89,7 @@ xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features
 xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.18" }
 
 # Moonbeam Dependencies
-# TODO: change branch to oak-polkadot-v0.19.8 before merging
-parachain-staking = { git = "https://github.com/OAK-Foundation/moonbeam", default-features = false, branch = "nikhil/oak-polkadot-v0.9.18" }
+parachain-staking = { git = "https://github.com/OAK-Foundation/moonbeam", default-features = false, branch = "oak-polkadot-v0.9.18" }
 
 [features]
 default = [

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -436,10 +436,9 @@ parameter_types! {
 impl pallet_session::Config for Runtime {
 	type Event = Event;
 	type ValidatorId = <Self as frame_system::Config>::AccountId;
-	// we don't have stash and controller, thus we don't need the convert as well.
 	type ValidatorIdOf = ConvertInto;
-	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
-	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
+	type ShouldEndSession = ParachainStaking;
+	type NextSessionRotation = ParachainStaking;
 	type SessionManager = ParachainStaking;
 	// Essentially just Aura, but lets be pedantic.
 	type SessionHandler = <SessionKeys as sp_runtime::traits::OpaqueKeys>::KeyTypeIdProviders;

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -457,7 +457,7 @@ parameter_types! {
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
 	/// Default percent of inflation set aside for parachain bond every round
 	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
-	pub const DefaultBlocksPerRound: u32 = 1 * MINUTES;
+	pub const DefaultBlocksPerRound: u32 = 5 * MINUTES;
 }
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
@@ -480,23 +480,23 @@ impl parachain_staking::Config for Runtime {
 	/// Rounds before the reward is paid
 	type RewardPaymentDelay = ConstU32<2>;
 	/// Minimum collators selected per round, default at genesis and minimum forever after
-	type MinSelectedCandidates = ConstU32<2>;
+	type MinSelectedCandidates = ConstU32<8>;
 	/// Maximum top delegations per candidate
-	type MaxTopDelegationsPerCandidate = ConstU32<2>;
+	type MaxTopDelegationsPerCandidate = ConstU32<10>;
 	/// Maximum bottom delegations per candidate
-	type MaxBottomDelegationsPerCandidate = ConstU32<2>;
+	type MaxBottomDelegationsPerCandidate = ConstU32<50>;
 	/// Maximum delegations per delegator
-	type MaxDelegationsPerDelegator = ConstU32<3>;
+	type MaxDelegationsPerDelegator = ConstU32<10>;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
 	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	/// Minimum stake required to become a collator
-	type MinCollatorStk = ConstU128<1_000_000_000_000>;
+	type MinCollatorStk = ConstU128<{ 1_000_000 * DOLLAR }>;
 	/// Minimum stake required to be reserved to be a candidate
-	type MinCandidateStk = ConstU128<100_000_000_000>;
+	type MinCandidateStk = ConstU128<{ 500 * DOLLAR }>;
 	/// Minimum delegation amount after initial
-	type MinDelegation = ConstU128<50_000_000_000>;
+	type MinDelegation = ConstU128<{ 50 * DOLLAR }>;
 	/// Minimum initial stake required to be reserved to be a delegator
-	type MinDelegatorStk = ConstU128<30_000_000_000>;
+	type MinDelegatorStk = ConstU128<{ 50 * DOLLAR }>;
 	type WeightInfo = parachain_staking::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -468,35 +468,35 @@ impl parachain_staking::Config for Runtime {
 	/// Blocks per round
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	/// Rounds before the collator leaving the candidates request can be executed
-	type LeaveCandidatesDelay = ConstU32<24>;
+	type LeaveCandidatesDelay = ConstU32<2>;
 	/// Rounds before the candidate bond increase/decrease can be executed
-	type CandidateBondLessDelay = ConstU32<24>;
+	type CandidateBondLessDelay = ConstU32<2>;
 	/// Rounds before the delegator exit can be executed
-	type LeaveDelegatorsDelay = ConstU32<24>;
+	type LeaveDelegatorsDelay = ConstU32<2>;
 	/// Rounds before the delegator revocation can be executed
-	type RevokeDelegationDelay = ConstU32<24>;
+	type RevokeDelegationDelay = ConstU32<2>;
 	/// Rounds before the delegator bond increase/decrease can be executed
-	type DelegationBondLessDelay = ConstU32<24>;
+	type DelegationBondLessDelay = ConstU32<2>;
 	/// Rounds before the reward is paid
 	type RewardPaymentDelay = ConstU32<2>;
 	/// Minimum collators selected per round, default at genesis and minimum forever after
 	type MinSelectedCandidates = ConstU32<2>;
 	/// Maximum top delegations per candidate
-	type MaxTopDelegationsPerCandidate = ConstU32<300>;
+	type MaxTopDelegationsPerCandidate = ConstU32<2>;
 	/// Maximum bottom delegations per candidate
-	type MaxBottomDelegationsPerCandidate = ConstU32<50>;
+	type MaxBottomDelegationsPerCandidate = ConstU32<2>;
 	/// Maximum delegations per delegator
-	type MaxDelegationsPerDelegator = ConstU32<100>;
+	type MaxDelegationsPerDelegator = ConstU32<3>;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
 	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	/// Minimum stake required to become a collator
-	type MinCollatorStk = ConstU128<1_000_000_000>;
+	type MinCollatorStk = ConstU128<1_000_000_000_000>;
 	/// Minimum stake required to be reserved to be a candidate
-	type MinCandidateStk = ConstU128<1_000_000>;
-	/// Minimum stake required to be reserved to be a delegator
-	type MinDelegation = ConstU128<100>;
-	/// Minimum stake required to be reserved to be a delegator
-	type MinDelegatorStk = ConstU128<1_000>;
+	type MinCandidateStk = ConstU128<100_000_000_000>;
+	/// Minimum delegation amount after initial
+	type MinDelegation = ConstU128<50_000_000_000>;
+	/// Minimum initial stake required to be reserved to be a delegator
+	type MinDelegatorStk = ConstU128<30_000_000_000>;
 	type WeightInfo = parachain_staking::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -832,10 +832,10 @@ construct_runtime!(
 
 		// Collator support. The order of these 4 are important and shall not change.
 		Authorship: pallet_authorship::{Pallet, Call, Storage} = 20,
-		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 22,
+		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 21,
+		ParachainStaking: parachain_staking::{Pallet, Call, Storage, Event<T>, Config<T>} = 22,
 		Aura: pallet_aura::{Pallet, Storage, Config<T>} = 23,
 		AuraExt: cumulus_pallet_aura_ext::{Pallet, Storage, Config} = 24,
-		ParachainStaking: parachain_staking::{Pallet, Call, Storage, Event<T>, Config<T>} = 25,
 
 		// Utilities
 		Valve: pallet_valve::{Pallet, Call, Config, Storage, Event<T>} = 30,

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -990,12 +990,14 @@ impl_runtime_apis! {
 			use pallet_automation_time::Pallet as AutomationTime;
 			use pallet_valve::Pallet as Valve;
 			use pallet_vesting::Pallet as Vesting;
+			use parachain_staking::Pallet as ParachainStaking;
 
 			let mut list = Vec::<BenchmarkList>::new();
 
 			list_benchmark!(list, extra, pallet_automation_time, AutomationTime::<Runtime>);
 			list_benchmark!(list, extra, pallet_valve, Valve::<Runtime>);
 			list_benchmark!(list, extra, pallet_vesting, Vesting::<Runtime>);
+			list_benchmark!(list, extra, parachain_staking, ParachainStaking::<Runtime>);
 
 			let storage_info = AllPalletsWithSystem::storage_info();
 
@@ -1011,6 +1013,7 @@ impl_runtime_apis! {
 			use pallet_automation_time::Pallet as AutomationTime;
 			use pallet_valve::Pallet as Valve;
 			use pallet_vesting::Pallet as Vesting;
+			use parachain_staking::Pallet as ParachainStaking;
 
 			let whitelist: Vec<TrackedStorageKey> = vec![
 				// Block Number
@@ -1031,6 +1034,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_automation_time, AutomationTime::<Runtime>);
 			add_benchmark!(params, batches, pallet_valve, Valve::<Runtime>);
 			add_benchmark!(params, batches, pallet_vesting, Vesting::<Runtime>);
+			add_benchmark!(params, batches, parachain_staking, ParachainStaking::<Runtime>);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -110,6 +110,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	parachain_staking::InitGenesisOnRuntimeUpgrade<Runtime>,
 >;
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -792,6 +792,7 @@ impl Contains<Call> for ClosedCallFilter {
 			Call::AutomationTime(_) => false,
 			Call::Balances(_) => false,
 			Call::Bounties(_) => false,
+			Call::ParachainStaking(_) => false,
 			Call::Treasury(_) => false,
 			_ => true,
 		}

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -453,15 +453,6 @@ impl pallet_aura::Config for Runtime {
 }
 
 parameter_types! {
-	pub const PotId: PalletId = PalletId(*b"PotStake");
-	pub const MaxCandidates: u32 = 5;
-	pub const MinCandidates: u32 = 1;
-	pub const SessionLength: BlockNumber = 6 * HOURS;
-	pub const MaxInvulnerables: u32 = 100;
-	pub const ExecutiveBody: BodyId = BodyId::Executive;
-}
-
-parameter_types! {
 	/// Default fixed percent a collator takes off the top of due rewards
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
 	/// Default percent of inflation set aside for parachain bond every round

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -461,25 +461,6 @@ parameter_types! {
 	pub const ExecutiveBody: BodyId = BodyId::Executive;
 }
 
-// We allow root only to execute privileged collator selection operations.
-pub type CollatorSelectionUpdateOrigin = EnsureRoot<AccountId>;
-
-impl pallet_collator_selection::Config for Runtime {
-	type Event = Event;
-	type Currency = Balances;
-	type UpdateOrigin = CollatorSelectionUpdateOrigin;
-	type PotId = PotId;
-	type MaxCandidates = MaxCandidates;
-	type MinCandidates = MinCandidates;
-	type MaxInvulnerables = MaxInvulnerables;
-	// should be a multiple of session or things will get inconsistent
-	type KickThreshold = Period;
-	type ValidatorId = <Self as frame_system::Config>::AccountId;
-	type ValidatorIdOf = ConvertInto;
-	type ValidatorRegistration = Session;
-	type WeightInfo = ();
-}
-
 parameter_types! {
 	/// Default fixed percent a collator takes off the top of due rewards
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
@@ -819,7 +800,6 @@ impl Contains<Call> for ClosedCallFilter {
 			Call::AutomationTime(_) => false,
 			Call::Balances(_) => false,
 			Call::Bounties(_) => false,
-			Call::CollatorSelection(_) => false,
 			Call::Treasury(_) => false,
 			_ => true,
 		}
@@ -859,7 +839,6 @@ construct_runtime!(
 
 		// Collator support. The order of these 4 are important and shall not change.
 		Authorship: pallet_authorship::{Pallet, Call, Storage} = 20,
-		CollatorSelection: pallet_collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>} = 21,
 		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 22,
 		Aura: pallet_aura::{Pallet, Storage, Config<T>} = 23,
 		AuraExt: cumulus_pallet_aura_ext::{Pallet, Storage, Config} = 24,

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -110,7 +110,6 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	parachain_staking::InitGenesisOnRuntimeUpgrade<Runtime>,
 >;
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -458,7 +458,6 @@ parameter_types! {
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
 	/// Default percent of inflation set aside for parachain bond every round
 	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
-	pub const DefaultBlocksPerRound: u32 = 5 * MINUTES;
 }
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
@@ -467,7 +466,7 @@ impl parachain_staking::Config for Runtime {
 	/// Minimum round length is 2 minutes (10 * 12 second block times)
 	type MinBlocksPerRound = ConstU32<10>;
 	/// Blocks per round
-	type DefaultBlocksPerRound = DefaultBlocksPerRound;
+	type DefaultBlocksPerRound = ConstU32<{ 5 * MINUTES }>;
 	/// Rounds before the collator leaving the candidates request can be executed
 	type LeaveCandidatesDelay = ConstU32<2>;
 	/// Rounds before the candidate bond increase/decrease can be executed

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -458,6 +458,7 @@ parameter_types! {
 	/// Default percent of inflation set aside for parachain bond every round
 	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
 	pub const DefaultBlocksPerRound: u32 = 10 * MINUTES;
+	pub const  MinCollatorStk: u128 = 1_000_000_000;
 }
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
@@ -490,7 +491,7 @@ impl parachain_staking::Config for Runtime {
 	type DefaultCollatorCommission = DefaultCollatorCommission;
 	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	/// Minimum stake required to become a collator
-	type MinCollatorStk = ConstU128<1_000_000_000>;
+	type MinCollatorStk = MinCollatorStk;
 	/// Minimum stake required to be reserved to be a candidate
 	type MinCandidateStk = ConstU128<1_000_000>;
 	/// Minimum stake required to be reserved to be a delegator

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -165,10 +165,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("neumann"),
 	impl_name: create_runtime_str!("neumann"),
 	authoring_version: 1,
-	spec_version: 279,
+	spec_version: 280,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 6,
+	transaction_version: 7,
 	state_version: 0,
 };
 

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -479,7 +479,7 @@ impl parachain_staking::Config for Runtime {
 	/// Rounds before the reward is paid
 	type RewardPaymentDelay = ConstU32<2>;
 	/// Minimum collators selected per round, default at genesis and minimum forever after
-	type MinSelectedCandidates = ConstU32<8>;
+	type MinSelectedCandidates = ConstU32<5>;
 	/// Maximum top delegations per candidate
 	type MaxTopDelegationsPerCandidate = ConstU32<10>;
 	/// Maximum bottom delegations per candidate

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -466,6 +466,7 @@ parameter_types! {
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
 	/// Default percent of inflation set aside for parachain bond every round
 	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
+	pub const DefaultBlocksPerRound: u32 = 2 * HOURS;
 }
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
@@ -474,7 +475,7 @@ impl parachain_staking::Config for Runtime {
 	/// Minimum round length is 2 minutes (10 * 12 second block times)
 	type MinBlocksPerRound = frame_support::traits::ConstU32<10>;
 	/// Blocks per round
-	type DefaultBlocksPerRound = frame_support::traits::ConstU32<{ 2 * HOURS }>;
+	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	/// Rounds before the collator leaving the candidates request can be executed
 	type LeaveCandidatesDelay = frame_support::traits::ConstU32<24>;
 	/// Rounds before the candidate bond increase/decrease can be executed

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -39,7 +39,7 @@ use sp_version::RuntimeVersion;
 
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Contains, EnsureOneOf, Imbalance, OnUnbalanced, PrivilegeCmp},
+	traits::{ConstU128, ConstU32, Contains, EnsureOneOf, Imbalance, OnUnbalanced, PrivilegeCmp},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, WEIGHT_PER_SECOND},
 		DispatchClass, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients,
@@ -303,7 +303,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = SS58Prefix;
 	/// The action to take on a Runtime Upgrade
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = ConstU32<16>;
 }
 
 parameter_types! {
@@ -457,46 +457,46 @@ parameter_types! {
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
 	/// Default percent of inflation set aside for parachain bond every round
 	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
-	pub const DefaultBlocksPerRound: u32 = 2 * HOURS;
+	pub const DefaultBlocksPerRound: u32 = 10 * MINUTES;
 }
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
 	type MonetaryGovernanceOrigin = EnsureRoot<AccountId>;
 	/// Minimum round length is 2 minutes (10 * 12 second block times)
-	type MinBlocksPerRound = frame_support::traits::ConstU32<10>;
+	type MinBlocksPerRound = ConstU32<10>;
 	/// Blocks per round
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	/// Rounds before the collator leaving the candidates request can be executed
-	type LeaveCandidatesDelay = frame_support::traits::ConstU32<24>;
+	type LeaveCandidatesDelay = ConstU32<24>;
 	/// Rounds before the candidate bond increase/decrease can be executed
-	type CandidateBondLessDelay = frame_support::traits::ConstU32<24>;
+	type CandidateBondLessDelay = ConstU32<24>;
 	/// Rounds before the delegator exit can be executed
-	type LeaveDelegatorsDelay = frame_support::traits::ConstU32<24>;
+	type LeaveDelegatorsDelay = ConstU32<24>;
 	/// Rounds before the delegator revocation can be executed
-	type RevokeDelegationDelay = frame_support::traits::ConstU32<24>;
+	type RevokeDelegationDelay = ConstU32<24>;
 	/// Rounds before the delegator bond increase/decrease can be executed
-	type DelegationBondLessDelay = frame_support::traits::ConstU32<24>;
+	type DelegationBondLessDelay = ConstU32<24>;
 	/// Rounds before the reward is paid
-	type RewardPaymentDelay = frame_support::traits::ConstU32<2>;
+	type RewardPaymentDelay = ConstU32<2>;
 	/// Minimum collators selected per round, default at genesis and minimum forever after
-	type MinSelectedCandidates = frame_support::traits::ConstU32<8>;
+	type MinSelectedCandidates = ConstU32<2>;
 	/// Maximum top delegations per candidate
-	type MaxTopDelegationsPerCandidate = frame_support::traits::ConstU32<300>;
+	type MaxTopDelegationsPerCandidate = ConstU32<300>;
 	/// Maximum bottom delegations per candidate
-	type MaxBottomDelegationsPerCandidate = frame_support::traits::ConstU32<50>;
+	type MaxBottomDelegationsPerCandidate = ConstU32<50>;
 	/// Maximum delegations per delegator
-	type MaxDelegationsPerDelegator = frame_support::traits::ConstU32<100>;
+	type MaxDelegationsPerDelegator = ConstU32<100>;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
 	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	/// Minimum stake required to become a collator
-	type MinCollatorStk = frame_support::traits::ConstU128<{ 1000 * 1_000_000_000_000_000_000 }>;
+	type MinCollatorStk = ConstU128<1_000_000_000>;
 	/// Minimum stake required to be reserved to be a candidate
-	type MinCandidateStk = frame_support::traits::ConstU128<{ 500 * 1_000_000_000_000_000_000 }>;
+	type MinCandidateStk = ConstU128<1_000_000>;
 	/// Minimum stake required to be reserved to be a delegator
-	type MinDelegation = frame_support::traits::ConstU128<{ 5 * 1_000_000_000_000_000_000 }>;
+	type MinDelegation = ConstU128<100>;
 	/// Minimum stake required to be reserved to be a delegator
-	type MinDelegatorStk = frame_support::traits::ConstU128<{ 5 * 1_000_000_000_000_000_000 }>;
+	type MinDelegatorStk = ConstU128<1_000>;
 	type WeightInfo = parachain_staking::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -457,8 +457,7 @@ parameter_types! {
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
 	/// Default percent of inflation set aside for parachain bond every round
 	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
-	pub const DefaultBlocksPerRound: u32 = 10 * MINUTES;
-	pub const  MinCollatorStk: u128 = 1_000_000_000;
+	pub const DefaultBlocksPerRound: u32 = 1 * MINUTES;
 }
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
@@ -491,7 +490,7 @@ impl parachain_staking::Config for Runtime {
 	type DefaultCollatorCommission = DefaultCollatorCommission;
 	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	/// Minimum stake required to become a collator
-	type MinCollatorStk = MinCollatorStk;
+	type MinCollatorStk = ConstU128<1_000_000_000>;
 	/// Minimum stake required to be reserved to be a candidate
 	type MinCandidateStk = ConstU128<1_000_000>;
 	/// Minimum stake required to be reserved to be a delegator

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -326,7 +326,7 @@ impl pallet_authorship::Config for Runtime {
 	type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
 	type UncleGenerations = UncleGenerations;
 	type FilterUncle = ();
-	type EventHandler = (CollatorSelection,);
+	type EventHandler = ParachainStaking;
 }
 
 parameter_types! {

--- a/runtime/turing/Cargo.toml
+++ b/runtime/turing/Cargo.toml
@@ -78,7 +78,6 @@ cumulus-pallet-xcmp-queue = { git = 'https://github.com/paritytech/cumulus', bra
 cumulus-primitives-core = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.18', default-features = false }
 cumulus-primitives-timestamp = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.18', default-features = false }
 cumulus-primitives-utility = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.18', default-features = false }
-pallet-collator-selection = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.18', default-features = false }
 parachain-info = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.18', default-features = false }
 
 # Polkadot Dependencies
@@ -88,6 +87,9 @@ polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", defa
 xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.18" }
 xcm-builder = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.18" }
 xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.18" }
+
+# Moonbeam Dependencies
+parachain-staking = { git = "https://github.com/OAK-Foundation/moonbeam", default-features = false, branch = "oak-polkadot-v0.9.18" }
 
 [features]
 default = [
@@ -120,7 +122,6 @@ std = [
 	"pallet-automation-time-rpc-runtime-api/std",
 	"pallet-balances/std",
 	"pallet-bounties/std",
-	"pallet-collator-selection/std",
 	"pallet-collective/std",
 	"pallet-democracy/std",
 	"pallet-membership/std",
@@ -134,6 +135,7 @@ std = [
 	"pallet-transaction-payment/std",
 	"pallet-valve/std",
 	"pallet-vesting/std",
+	"parachain-staking/std",
 	"primitives/std",
 	"cumulus-pallet-aura-ext/std",
 	"cumulus-pallet-parachain-system/std",
@@ -161,11 +163,11 @@ runtime-benchmarks = [
 	"pallet-automation-time/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-bounties/runtime-benchmarks",
-	"pallet-collator-selection/runtime-benchmarks",
 	"pallet-collective/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-treasury/runtime-benchmarks",
 	"pallet-valve/runtime-benchmarks",
 	"pallet-vesting/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
+	"parachain-staking/runtime-benchmarks",
 ]

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -627,33 +627,33 @@ impl parachain_staking::Config for Runtime {
 	/// Minimum round length is 2 minutes (10 * 12 second block times)
 	type MinBlocksPerRound = ConstU32<10>;
 	/// Blocks per round
-	type DefaultBlocksPerRound = ConstU32<{ 5 * MINUTES }>;
+	type DefaultBlocksPerRound = ConstU32<{ 2 * HOURS }>;
 	/// Rounds before the collator leaving the candidates request can be executed
-	type LeaveCandidatesDelay = ConstU32<2>;
+	type LeaveCandidatesDelay = ConstU32<24>;
 	/// Rounds before the candidate bond increase/decrease can be executed
-	type CandidateBondLessDelay = ConstU32<2>;
+	type CandidateBondLessDelay = ConstU32<24>;
 	/// Rounds before the delegator exit can be executed
-	type LeaveDelegatorsDelay = ConstU32<2>;
+	type LeaveDelegatorsDelay = ConstU32<24>;
 	/// Rounds before the delegator revocation can be executed
-	type RevokeDelegationDelay = ConstU32<2>;
+	type RevokeDelegationDelay = ConstU32<24>;
 	/// Rounds before the delegator bond increase/decrease can be executed
-	type DelegationBondLessDelay = ConstU32<2>;
+	type DelegationBondLessDelay = ConstU32<24>;
 	/// Rounds before the reward is paid
 	type RewardPaymentDelay = ConstU32<2>;
 	/// Minimum collators selected per round, default at genesis and minimum forever after
-	type MinSelectedCandidates = ConstU32<8>;
+	type MinSelectedCandidates = ConstU32<5>;
 	/// Maximum top delegations per candidate
-	type MaxTopDelegationsPerCandidate = ConstU32<10>;
+	type MaxTopDelegationsPerCandidate = ConstU32<300>;
 	/// Maximum bottom delegations per candidate
 	type MaxBottomDelegationsPerCandidate = ConstU32<50>;
 	/// Maximum delegations per delegator
-	type MaxDelegationsPerDelegator = ConstU32<10>;
+	type MaxDelegationsPerDelegator = ConstU32<100>;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
 	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	/// Minimum stake required to become a collator
-	type MinCollatorStk = ConstU128<{ 1_000_000 * DOLLAR }>;
+	type MinCollatorStk = ConstU128<{ 400_000 * DOLLAR }>;
 	/// Minimum stake required to be reserved to be a candidate
-	type MinCandidateStk = ConstU128<{ 500 * DOLLAR }>;
+	type MinCandidateStk = ConstU128<{ 400_000 * DOLLAR }>;
 	/// Minimum delegation amount after initial
 	type MinDelegation = ConstU128<{ 50 * DOLLAR }>;
 	/// Minimum initial stake required to be reserved to be a delegator

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -27,7 +27,7 @@ use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT},
+	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, FixedPointNumber, Percent,
 };
@@ -39,7 +39,10 @@ use sp_version::RuntimeVersion;
 
 use frame_support::{
 	construct_runtime, match_type, parameter_types,
-	traits::{Contains, EnsureOneOf, Everything, Imbalance, Nothing, OnUnbalanced, PrivilegeCmp},
+	traits::{
+		ConstU128, ConstU32, Contains, EnsureOneOf, Everything, Imbalance, Nothing, OnUnbalanced,
+		PrivilegeCmp,
+	},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, WEIGHT_PER_SECOND},
 		DispatchClass, IdentityFee, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients,
@@ -172,10 +175,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("turing"),
 	impl_name: create_runtime_str!("turing"),
 	authoring_version: 1,
-	spec_version: 279,
+	spec_version: 280,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 6,
+	transaction_version: 7,
 	state_version: 0,
 };
 
@@ -310,7 +313,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = SS58Prefix;
 	/// The action to take on a Runtime Upgrade
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = ConstU32<16>;
 }
 
 parameter_types! {
@@ -333,7 +336,7 @@ impl pallet_authorship::Config for Runtime {
 	type FindAuthor = pallet_session::FindAccountFromAuthorIndex<Self, Aura>;
 	type UncleGenerations = UncleGenerations;
 	type FilterUncle = ();
-	type EventHandler = (CollatorSelection,);
+	type EventHandler = ParachainStaking;
 }
 
 parameter_types! {
@@ -595,11 +598,10 @@ parameter_types! {
 impl pallet_session::Config for Runtime {
 	type Event = Event;
 	type ValidatorId = <Self as frame_system::Config>::AccountId;
-	// we don't have stash and controller, thus we don't need the convert as well.
-	type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
-	type ShouldEndSession = pallet_session::PeriodicSessions<Period, Offset>;
-	type NextSessionRotation = pallet_session::PeriodicSessions<Period, Offset>;
-	type SessionManager = CollatorSelection;
+	type ValidatorIdOf = ConvertInto;
+	type ShouldEndSession = ParachainStaking;
+	type NextSessionRotation = ParachainStaking;
+	type SessionManager = ParachainStaking;
 	// Essentially just Aura, but lets be pedantic.
 	type SessionHandler = <SessionKeys as sp_runtime::traits::OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = SessionKeys;
@@ -613,31 +615,50 @@ impl pallet_aura::Config for Runtime {
 }
 
 parameter_types! {
-	pub const PotId: PalletId = PalletId(*b"PotStake");
-	pub const MaxCandidates: u32 = 5;
-	pub const MinCandidates: u32 = 1;
-	pub const SessionLength: BlockNumber = 6 * HOURS;
-	pub const MaxInvulnerables: u32 = 100;
-	pub const ExecutiveBody: BodyId = BodyId::Executive;
+	/// Default fixed percent a collator takes off the top of due rewards
+	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
+	/// Default percent of inflation set aside for parachain bond every round
+	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
 }
-
-// We allow root only to execute privileged collator selection operations.
-pub type CollatorSelectionUpdateOrigin = EnsureRoot<AccountId>;
-
-impl pallet_collator_selection::Config for Runtime {
+impl parachain_staking::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
-	type UpdateOrigin = CollatorSelectionUpdateOrigin;
-	type PotId = PotId;
-	type MaxCandidates = MaxCandidates;
-	type MinCandidates = MinCandidates;
-	type MaxInvulnerables = MaxInvulnerables;
-	// should be a multiple of session or things will get inconsistent
-	type KickThreshold = Period;
-	type ValidatorId = <Self as frame_system::Config>::AccountId;
-	type ValidatorIdOf = pallet_collator_selection::IdentityCollator;
-	type ValidatorRegistration = Session;
-	type WeightInfo = ();
+	type MonetaryGovernanceOrigin = EnsureRoot<AccountId>;
+	/// Minimum round length is 2 minutes (10 * 12 second block times)
+	type MinBlocksPerRound = ConstU32<10>;
+	/// Blocks per round
+	type DefaultBlocksPerRound = ConstU32<{ 5 * MINUTES }>;
+	/// Rounds before the collator leaving the candidates request can be executed
+	type LeaveCandidatesDelay = ConstU32<2>;
+	/// Rounds before the candidate bond increase/decrease can be executed
+	type CandidateBondLessDelay = ConstU32<2>;
+	/// Rounds before the delegator exit can be executed
+	type LeaveDelegatorsDelay = ConstU32<2>;
+	/// Rounds before the delegator revocation can be executed
+	type RevokeDelegationDelay = ConstU32<2>;
+	/// Rounds before the delegator bond increase/decrease can be executed
+	type DelegationBondLessDelay = ConstU32<2>;
+	/// Rounds before the reward is paid
+	type RewardPaymentDelay = ConstU32<2>;
+	/// Minimum collators selected per round, default at genesis and minimum forever after
+	type MinSelectedCandidates = ConstU32<8>;
+	/// Maximum top delegations per candidate
+	type MaxTopDelegationsPerCandidate = ConstU32<10>;
+	/// Maximum bottom delegations per candidate
+	type MaxBottomDelegationsPerCandidate = ConstU32<50>;
+	/// Maximum delegations per delegator
+	type MaxDelegationsPerDelegator = ConstU32<10>;
+	type DefaultCollatorCommission = DefaultCollatorCommission;
+	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
+	/// Minimum stake required to become a collator
+	type MinCollatorStk = ConstU128<{ 1_000_000 * DOLLAR }>;
+	/// Minimum stake required to be reserved to be a candidate
+	type MinCandidateStk = ConstU128<{ 500 * DOLLAR }>;
+	/// Minimum delegation amount after initial
+	type MinDelegation = ConstU128<{ 50 * DOLLAR }>;
+	/// Minimum initial stake required to be reserved to be a delegator
+	type MinDelegatorStk = ConstU128<{ 50 * DOLLAR }>;
+	type WeightInfo = parachain_staking::weights::SubstrateWeight<Runtime>;
 }
 
 parameter_types! {
@@ -935,7 +956,7 @@ impl Contains<Call> for ClosedCallFilter {
 			Call::AutomationTime(_) => false,
 			Call::Balances(_) => false,
 			Call::Bounties(_) => false,
-			Call::CollatorSelection(_) => false,
+			Call::ParachainStaking(_) => false,
 			Call::Treasury(_) => false,
 			_ => true,
 		}
@@ -975,8 +996,8 @@ construct_runtime!(
 
 		// Collator support. The order of these 4 are important and shall not change.
 		Authorship: pallet_authorship::{Pallet, Call, Storage} = 20,
-		CollatorSelection: pallet_collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>} = 21,
-		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 22,
+		Session: pallet_session::{Pallet, Call, Storage, Event, Config<T>} = 21,
+		ParachainStaking: parachain_staking::{Pallet, Call, Storage, Event<T>, Config<T>} = 22,
 		Aura: pallet_aura::{Pallet, Storage, Config<T>} = 23,
 		AuraExt: cumulus_pallet_aura_ext::{Pallet, Storage, Config} = 24,
 
@@ -1131,12 +1152,14 @@ impl_runtime_apis! {
 			use pallet_automation_time::Pallet as AutomationTime;
 			use pallet_valve::Pallet as Valve;
 			use pallet_vesting::Pallet as Vesting;
+			use parachain_staking::Pallet as ParachainStaking;
 
 			let mut list = Vec::<BenchmarkList>::new();
 
 			list_benchmark!(list, extra, pallet_automation_time, AutomationTime::<Runtime>);
 			list_benchmark!(list, extra, pallet_valve, Valve::<Runtime>);
 			list_benchmark!(list, extra, pallet_vesting, Vesting::<Runtime>);
+			list_benchmark!(list, extra, parachain_staking, ParachainStaking::<Runtime>);
 
 			let storage_info = AllPalletsWithSystem::storage_info();
 
@@ -1152,6 +1175,7 @@ impl_runtime_apis! {
 			use pallet_automation_time::Pallet as AutomationTime;
 			use pallet_valve::Pallet as Valve;
 			use pallet_vesting::Pallet as Vesting;
+			use parachain_staking::Pallet as ParachainStaking;
 
 			let whitelist: Vec<TrackedStorageKey> = vec![
 				// Block Number
@@ -1172,6 +1196,7 @@ impl_runtime_apis! {
 			add_benchmark!(params, batches, pallet_automation_time, AutomationTime::<Runtime>);
 			add_benchmark!(params, batches, pallet_valve, Valve::<Runtime>);
 			add_benchmark!(params, batches, pallet_vesting, Vesting::<Runtime>);
+			add_benchmark!(params, batches, parachain_staking, ParachainStaking::<Runtime>);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
 			Ok(batches)


### PR DESCRIPTION
This pr replaces collator-selection with parachain-staking. This migrates our chain from PoA (proof of authority) to dPoS (delegated proof of stake). Parachain-staking handles the mechanics of collator bonding and delegation, selection of the active set of collators, and payouts (through inflation) for successful block production.

### Basics

Parachain Staking sees the world through `rounds`. A `round` is a set of blocks with the same active set of collators. Currently 25 blocks/round or 5 minutes for Neumann.

Each round a new active set is determined by selecting n collators with the highest total stake (including delegations).
![image](https://user-images.githubusercontent.com/16072671/166081813-85b51cbf-8ac4-43fa-b59f-a035073c10e2.png)

At the beginning of each round collator and delegator rewards are paid out with 1 collator and associated delegators being paid out each block until everyone is paid. From a given payout 20% is reserved for the collator, 30% for the parachain bond fund, and the remaining 50% is split across stakers proportional to their stake. There is a configurable delay (# of rounds) before rewards are paid out.
![image](https://user-images.githubusercontent.com/16072671/166082624-498ebf1c-e76f-4263-aff4-1117bf167cec.png)

### How to become a collator candidate (numbers based on current proposal):

- Call `parachainStaking_joinCandidates` with at least the MinCollatorBond (500 NEU) to enter the candidatePool
- In order to become an eligible collator you'll need to hit the MinCollatorStk (1 MNEU). You can do this either by increasing your bond (candidateBondMore) or acquiring delegators.
- Delegators can bond to a candidate using `parachainStaking_delegate` with atleast 50 NEU
![image](https://user-images.githubusercontent.com/16072671/166079601-c60ae18f-595c-4df6-844f-ce076b88f56a.png)
![image](https://user-images.githubusercontent.com/16072671/166080714-350db8d3-db56-49e4-9bcb-d7ac5154211f.png)

### Notes on inflation/rewards

- Inflation defaults to 0. This allows us to keep rewards off until we're ready to enable them. Inflation is enabled using sudo with `parachainStaking_setStakingExpectations` and `parachainStaking_setInflation`. Note: Inflation is set using parts per billion.
- Until the parachain bond fund account is set through sudo `parachainStaking_setParachainBondAccount` the percentage payout that would have been reserved for the parachain bond goes to stakers.

### Session pallet, cumulus, nimbus

To reduce the size of this change and avoid a hard fork we opted to stick with cumulus concensus rather than migrate to nimbus. We've had to fork the parachain-staking pallet from moonbeam to implement the traits required by the session and authorship pallets.

Our fork of parachain-staking begins a new session every time the round is changed so we can think of 1 session == 1 round. On each new session the new set of active collators is passed to the session pallet to further filter specific authors for a given slot. We also implemented `note_author` from the authorship pallet to track and award collators for the blocks which they've authored.

__Important Note__: Since the session pallet is being used in conjunction with parachain-staking potential collators will need to register with both pallets to successfully author blocks. The session pallet requires registering the session key from `author_rotateKeys` with `session_setKeys`. If none of the active collator set from parachain-staking has registered keys with the session pallet the chain will brick.

### Runtime Upgrade

After the runtime upgrade the parachain-staking candidate pool will be empty. As long as the candidate pool is empty parachain-staking will be unable to pass any new collators to the session pallet so the session pallet will continue to use its existing set of collators. We will need to transfer funds to our current invulnerable collators so that they can bond and participate in the pos system.