### PR TITLE
Fix test coverage.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,18 +50,8 @@ jobs:
           rustup update stable
           rustup component add llvm-tools-preview
           cargo install grcov
+          cargo install rust-covfix
 
       - name: Test coverage
         run: |
-          export CARGO_INCREMENTAL=0
-          export SKIP_BUILD_WASM=true
-          export BUILD_DUMMY_WASM_BINARY=true
-          export LLVM_PROFILE_FILE="llvmcoveragedata-%p-%m.profraw"
-          export WASM_TARGET_DIRECTORY=/tmp/wasm
-          cargo build --features all-nodes
-          export RUSTFLAGS="-Zinstrument-coverage"
-          rm -rf target/debug
-          cargo test --all --features all-nodes
-          grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
-          bash <(curl -s https://codecov.io/bash) -f lcov.info
-          
+          sh ./maintain/test-coverage/test-coverage.sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: Test coverage
         run: |
-          sh ./maintain/test-coverage/test-coverage.sh
+          sh ./.maintain/test-coverage/test-coverage.sh

--- a/.maintain/test-coverage/test-coverage.sh
+++ b/.maintain/test-coverage/test-coverage.sh
@@ -1,0 +1,17 @@
+export CARGO_INCREMENTAL=0
+export SKIP_BUILD_WASM=true
+export BUILD_DUMMY_WASM_BINARY=true
+export LLVM_PROFILE_FILE="llvmcoveragedata-%p-%m.profraw"
+export WASM_TARGET_DIRECTORY=/tmp/wasm
+cargo build --features all-nodes
+export RUSTFLAGS="-Zinstrument-coverage"
+rm -rf target/debug
+cargo test --all --features all-nodes
+# grcov generate lcov.info
+# https://github.com/mozilla/grcov/blob/master/README.md
+# Ignore target/*, **test.rs
+grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" --ignore "target/*" --ignore "**tests.rs" -o lcov.info
+# Fix coverage
+# https://crates.io/crates/rust-covfix
+rust-covfix -o lcov_correct.info lcov.info
+bash <(curl -s https://codecov.io/bash) -f lcov_correct.info


### PR DESCRIPTION
1. grcov generate the coverage file: lcov.info.

Ignore target/*, **test.rs

```
grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" --ignore "target/*" --ignore "**tests.rs" -o lcov.info
```

doc: https://github.com/mozilla/grcov/blob/master/README.md

1. Fix coverage

```
rust-covfix -o lcov_correct.info lcov.info
```

doc: https://crates.io/crates/rust-covfix 

Result:
https://bugmoon.test.s3-website-us-east-1.amazonaws.com/coverage

<img width="1540" alt="image" src="https://user-images.githubusercontent.com/16951509/170508522-1112a7c6-9f57-47c0-b7eb-d840e5013ac8.png">

The test code in lib.rs will not be count.

<img width="908" alt="image" src="https://user-images.githubusercontent.com/16951509/170507401-ce1976ab-a44f-419f-bab2-5f2141334475.png">
