### PR TITLE
Increase turing minimum candidate self-bond

### DIFF
--- a/node/src/chain_spec/turing.rs
+++ b/node/src/chain_spec/turing.rs
@@ -105,6 +105,10 @@ fn testnet_genesis(
 	general_councils: Vec<AccountId>,
 	technical_memberships: Vec<AccountId>,
 ) -> turing_runtime::GenesisConfig {
+	let candidate_stake = std::cmp::max(
+		turing_runtime::MinCollatorStk::get(),
+		turing_runtime::MinCandidateStk::get(),
+	);
 	turing_runtime::GenesisConfig {
 		system: turing_runtime::SystemConfig {
 			code: turing_runtime::WASM_BINARY
@@ -130,7 +134,7 @@ fn testnet_genesis(
 			candidates: invulnerables
 				.iter()
 				.cloned()
-				.map(|(acc, _)| (acc, turing_runtime::MinCollatorStk::get()))
+				.map(|(acc, _)| (acc, candidate_stake))
 				.collect(),
 			delegations: vec![],
 			inflation_config: inflation_config(turing_runtime::DefaultBlocksPerRound::get()),

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -537,6 +537,8 @@ parameter_types! {
 	pub const DefaultBlocksPerRound: u32 = 2 * HOURS;
 	/// Minimum stake required to become a collator
 	pub const MinCollatorStk: u128 = 400_000 * DOLLAR;
+	/// Minimum stake required to be reserved to be a candidate
+	pub const MinCandidateStk: u128 = 2_000_000 * DOLLAR;
 }
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
@@ -568,8 +570,7 @@ impl parachain_staking::Config for Runtime {
 	type DefaultCollatorCommission = DefaultCollatorCommission;
 	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	type MinCollatorStk = MinCollatorStk;
-	/// Minimum stake required to be reserved to be a candidate
-	type MinCandidateStk = ConstU128<{ 400_000 * DOLLAR }>;
+	type MinCandidateStk = MinCandidateStk;
 	/// Minimum delegation amount after initial
 	type MinDelegation = ConstU128<{ 50 * DOLLAR }>;
 	/// Minimum initial stake required to be reserved to be a delegator


### PR DESCRIPTION
Increasing the candidate self bond from 400,000 to 2,000,000 tur in prep for enabling community collators outside the closed sale.