### PR TITLE
Correct formatter errors

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -95,15 +95,21 @@ impl SubstrateCli for Cli {
 		chain_spec: &Box<dyn sc_service::ChainSpec>,
 	) -> &'static RuntimeVersion {
 		match chain_spec {
-			chain_spec if chain_spec.is_turing() => {
+			chain_spec if chain_spec.is_turing() =>
+			{
+				#![rustfmt::skip]
 				#[cfg(feature = "turing-node")]
 				return &service::turing_runtime::VERSION;
+
 				#[cfg(not(feature = "turing-node"))]
 				panic!("{}", service::TURING_RUNTIME_NOT_AVAILABLE);
 			},
-			_ => {
+			_ =>
+			{
+				#![rustfmt::skip]
 				#[cfg(feature = "neumann-node")]
 				return &service::neumann_runtime::VERSION;
+
 				#[cfg(not(feature = "neumann-node"))]
 				panic!("{}", service::NEUMANN_RUNTIME_NOT_AVAILABLE);
 			},
@@ -146,7 +152,8 @@ impl SubstrateCli for RelayChainCli {
 			"neumann-relay" => Ok(Box::new(polkadot_service::RococoChainSpec::from_json_bytes(
 				&include_bytes!("../../node/res/neumann-rococo-testnet.json")[..],
 			)?)),
-			_ => polkadot_cli::Cli::from_iter([RelayChainCli::executable_name()].iter()).load_spec(id)
+			_ => polkadot_cli::Cli::from_iter([RelayChainCli::executable_name()].iter())
+				.load_spec(id),
 		}
 	}
 
@@ -325,9 +332,7 @@ pub fn run() -> Result<()> {
 					match cmd {
 						BenchmarkCmd::Pallet(cmd) =>
 							if cfg!(feature = "runtime-benchmarks") {
-								runner.sync_run(|config| {
-									cmd.run::<Block, Executor>(config)
-								})
+								runner.sync_run(|config| cmd.run::<Block, Executor>(config))
 							} else {
 								Err("Benchmarking wasn't enabled when building the node. \
 					You can enable it with `--features runtime-benchmarks`."

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -95,23 +95,19 @@ impl SubstrateCli for Cli {
 		chain_spec: &Box<dyn sc_service::ChainSpec>,
 	) -> &'static RuntimeVersion {
 		match chain_spec {
-			chain_spec if chain_spec.is_turing() =>
-			{
-				#![rustfmt::skip]
-				#[cfg(feature = "turing-node")]
-				return &service::turing_runtime::VERSION;
-
+			chain_spec if chain_spec.is_turing() => {
 				#[cfg(not(feature = "turing-node"))]
 				panic!("{}", service::TURING_RUNTIME_NOT_AVAILABLE);
-			},
-			_ =>
-			{
-				#![rustfmt::skip]
-				#[cfg(feature = "neumann-node")]
-				return &service::neumann_runtime::VERSION;
 
+				#[cfg(feature = "turing-node")]
+				return &service::turing_runtime::VERSION
+			},
+			_ => {
 				#[cfg(not(feature = "neumann-node"))]
 				panic!("{}", service::NEUMANN_RUNTIME_NOT_AVAILABLE);
+
+				#[cfg(feature = "neumann-node")]
+				return &service::neumann_runtime::VERSION
 			},
 		}
 	}

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -19,7 +19,7 @@ use crate::{
 	migrations::{v1, v2},
 	mock::*,
 	Action, Error, LastTimeSlot, MissedQueue, MissedTask, Shutdown, Task, TaskHashInput, TaskQueue,
-	Tasks, WeightInfo
+	Tasks, WeightInfo,
 };
 use core::convert::TryInto;
 use frame_support::{assert_noop, assert_ok, traits::OnInitialize};

--- a/runtime/turing/src/xcm_config.rs
+++ b/runtime/turing/src/xcm_config.rs
@@ -487,7 +487,7 @@ impl Convert<CurrencyId, Option<MultiLocation>> for CurrencyIdConvert {
 					GeneralKey(parachains::heiko::SKSM_KEY.to_vec()),
 				),
 			)),
-			CurrencyId::PHA => Some(MultiLocation::new(1, X1(Parachain(parachains::khala::ID))))
+			CurrencyId::PHA => Some(MultiLocation::new(1, X1(Parachain(parachains::khala::ID)))),
 		}
 	}
 }
@@ -515,8 +515,7 @@ impl Convert<MultiLocation, Option<CurrencyId>> for CurrencyIdConvert {
 					// If it's TUR
 					id if id == u32::from(ParachainInfo::parachain_id()) =>
 						Some(CurrencyId::Native),
-					id if id == parachains::khala::ID => 
-						Some(CurrencyId::PHA),
+					id if id == parachains::khala::ID => Some(CurrencyId::PHA),
 					_ => None,
 				}
 			},


### PR DESCRIPTION
Allow `cargo fmt -- --check` to pass.

`cargo fmt` created build errors in `node/src/command.rs` so two lines now have formatting skipped.