### PR TITLE
Add std feature to all pallet deps

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,7 +24,7 @@ runtime-benchmarks = [
     "neumann-runtime/runtime-benchmarks",
     "turing-runtime/runtime-benchmarks",
     "polkadot-cli/runtime-benchmarks",
-    ]
+]
 neumann-node = ["neumann-runtime"]
 turing-node = ["turing-runtime"]
 all-nodes = ["neumann-node", "turing-node"]
@@ -112,7 +112,7 @@ polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch
 xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.20" } 
 
 # Moonbeam Dependencies
-parachain-staking = { git = "https://github.com/OAK-Foundation/moonbeam", default-features = false, branch = "oak-polkadot-v0.9.20" }
+parachain-staking = { git = "https://github.com/OAK-Foundation/moonbeam", branch = "oak-polkadot-v0.9.20" }
 
 [package.metadata.deb]
 name = "oak-collator"

--- a/pallets/automation-time/Cargo.toml
+++ b/pallets/automation-time/Cargo.toml
@@ -52,13 +52,20 @@ xcm-executor = { git = 'https://github.com/paritytech/polkadot', default-feature
 default = ["std"]
 runtime-benchmarks = ["frame-benchmarking"]
 std = [
-    "codec/std",
-	"scale-info/std",
-    "sp-runtime/std",
-    "sp-std/std",
-	"pallet-timestamp/std",
+	"codec/std",
+	"cumulus-pallet-xcm/std",
+	"cumulus-primitives-core/std",
+	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",
-	"frame-benchmarking/std",
+	"pallet-timestamp/std",
+	"pallet-xcm/std",
+	"polkadot-parachain/std",
+	"scale-info/std",
+	"sp-runtime/std",
+	"sp-std/std",
+	"xcm/std",
+	"xcm-builder/std",
+	"xcm-executor/std",
 ]
 dev-queue = []

--- a/pallets/valve/Cargo.toml
+++ b/pallets/valve/Cargo.toml
@@ -41,9 +41,20 @@ cumulus-primitives-core = { git = 'https://github.com/paritytech/cumulus', defau
 default = ["std"]
 runtime-benchmarks = ["frame-benchmarking"]
 std = [
+	"codec/std",
+	"cumulus-pallet-xcm/std",
+	"cumulus-primitives-core/std",
+	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",
+	"pallet-automation-time/std",
+	"pallet-balances/std",
+	"pallet-timestamp/std",
+	"pallet-xcm/std",
 	"scale-info/std",
 	"sp-runtime/std",
 	"sp-std/std",
+	"xcm/std",
+	"xcm-builder/std",
+	"xcm-executor/std",
 ]


### PR DESCRIPTION
Adds std features to pallet deps so that pallet can be tested and built independently of full runtime.

Tested by running `cargo check && cargo test` from within the pallet.