### PR TITLE
Leverage Github generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,8 @@ jobs:
         with:
           name: turing-runtime
       - name: Generate notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.maintain/generate-release-notes ${{ github.event.inputs.tag }} > notes.md
       - name: Create release

--- a/.maintain/generate-release-notes
+++ b/.maintain/generate-release-notes
@@ -1,20 +1,17 @@
 #!/usr/bin/env bash
 
 tag=$1
-previous_tag=$(git tag | sort -r | head -n 2 | tail -n 1)
 
-echo "## What's Changed"
-echo
-
-changes=$(
-  git log $previous_tag...$tag --oneline | awk '{$1 = ""; print "*" $0}'
+notes=$(
+  curl -s -L \
+    -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    -d '{"tag_name":"'$tag'","target_commitish":"'$tag'"}' \
+    https://api.github.com/repos/OAK-Foundation/OAK-blockchain/releases/generate-notes
 )
 
-echo "$changes"
-echo
-
-github="https://github.com/OAK-Foundation/OAK-blockchain/compare"
-echo "**Full Changelog**: $github/$previous_tag...$tag"
+echo $notes | jq .body | sed -e 's/^"//' -e 's/"$//' -e 's/\\n/\n/g'
 echo
 
 echo "## Turing srtool output"


### PR DESCRIPTION
Github has an API that will generate release notes between patches. This matches the method that was previously used to generate release notes. Relevant new output:


```
## What's Changed
* Fix test coverage. by @imstar15 in https://github.com/OAK-Foundation/OAK-blockchain/pull/163
* Remove vesting set_total_unvested_allocation migration by @nvengal in https://github.com/OAK-Foundation/OAK-blockchain/pull/170
* remove turing-dev closed valves by @lreesby in https://github.com/OAK-Foundation/OAK-blockchain/pull/168
* Correct formatter errors by @atomaka in https://github.com/OAK-Foundation/OAK-blockchain/pull/173
* Use self-hosted runner for test suite by @atomaka in https://github.com/OAK-Foundation/OAK-blockchain/pull/162
* Prevent concurrent pr builds by @atomaka in https://github.com/OAK-Foundation/OAK-blockchain/pull/178
* Build Github workflow for release by @atomaka in https://github.com/OAK-Foundation/OAK-blockchain/pull/179
* turing and neuman governance parameters by @lreesby in https://github.com/OAK-Foundation/OAK-blockchain/pull/182
* version 141 and spec 283 bump by @lreesby in https://github.com/OAK-Foundation/OAK-blockchain/pull/183
* reverse node bump and update changelog to 1.4.0.1 by @lreesby in https://github.com/OAK-Foundation/OAK-blockchain/pull/184


**Full Changelog**: https://github.com/OAK-Foundation/OAK-blockchain/compare/v1.4.0...v1.4.0.1
```