### PR TITLE
Correct version display from adjusted srtool text

### DIFF
--- a/.maintain/generate-release-notes
+++ b/.maintain/generate-release-notes
@@ -19,8 +19,13 @@ echo
 
 runtime=$(cat turing-srtool-digest.json)
 rust=$(echo $runtime | jq --raw-output .rustc)
+spec=$(
+  echo $runtime \
+    | jq --raw-output .runtimes.compressed.subwasm.core_version.specName
+)
 version=$(
-  echo $runtime| jq --raw-output .runtimes.compressed.subwasm.core_version
+  echo $runtime \
+    | jq --raw-output .runtimes.compressed.subwasm.core_version.specVersion
 )
 size=$(echo $runtime| jq --raw-output .runtimes.compressed.size)
 proposal=$(echo $runtime | jq --raw-output .runtimes.compressed.prop)
@@ -30,7 +35,7 @@ blake2_256=$(echo $runtime | jq --raw-output .runtimes.compressed.blake2_256)
 cat <<-EOF
 \`\`\`
 Rust        : $rust
-Version     : $version
+Version     : $spec-$version
 Size        : $size
 Proposal    : $proposal
 IPFS        : $ipfs

--- a/.maintain/generate-release-notes
+++ b/.maintain/generate-release-notes
@@ -51,7 +51,6 @@ blake2_256=$(echo $runtime | jq --raw-output .runtimes.compressed.blake2_256)
 cat <<-EOF
 \`\`\`
 Rust        : $rust
-(turing-1.tx9.au1)
 Version     : $spec-$version ($impl_name-$impl_version.tx$transaction_version.au$authoring_version)
 Size        : $size
 Proposal    : $proposal

--- a/.maintain/generate-release-notes
+++ b/.maintain/generate-release-notes
@@ -23,9 +23,25 @@ spec=$(
   echo $runtime \
     | jq --raw-output .runtimes.compressed.subwasm.core_version.specName
 )
+impl_name=$(
+  echo $runtime \
+    | jq --raw-output .runtimes.compressed.subwasm.core_version.implName
+)
 version=$(
   echo $runtime \
     | jq --raw-output .runtimes.compressed.subwasm.core_version.specVersion
+)
+impl_version=$(
+  echo $runtime \
+    | jq --raw-output .runtimes.compressed.subwasm.core_version.implVersion
+)
+authoring_version=$(
+  echo $runtime \
+    | jq --raw-output .runtimes.compressed.subwasm.core_version.authoringVersion
+)
+transaction_version=$(
+  echo $runtime \
+    | jq --raw-output .runtimes.compressed.subwasm.core_version.transactionVersion
 )
 size=$(echo $runtime| jq --raw-output .runtimes.compressed.size)
 proposal=$(echo $runtime | jq --raw-output .runtimes.compressed.prop)
@@ -35,7 +51,8 @@ blake2_256=$(echo $runtime | jq --raw-output .runtimes.compressed.blake2_256)
 cat <<-EOF
 \`\`\`
 Rust        : $rust
-Version     : $spec-$version
+(turing-1.tx9.au1)
+Version     : $spec-$version ($impl_name-$impl_version.tx$transaction_version.au$authoring_version)
 Size        : $size
 Proposal    : $proposal
 IPFS        : $ipfs

--- a/.maintain/generate-release-notes
+++ b/.maintain/generate-release-notes
@@ -19,7 +19,7 @@ echo
 
 runtime=$(cat turing-srtool-digest.json)
 rust=$(echo $runtime | jq --raw-output .rustc)
-spec=$(
+spec_name=$(
   echo $runtime \
     | jq --raw-output .runtimes.compressed.subwasm.core_version.specName
 )
@@ -27,7 +27,7 @@ impl_name=$(
   echo $runtime \
     | jq --raw-output .runtimes.compressed.subwasm.core_version.implName
 )
-version=$(
+spec_version=$(
   echo $runtime \
     | jq --raw-output .runtimes.compressed.subwasm.core_version.specVersion
 )
@@ -48,10 +48,13 @@ proposal=$(echo $runtime | jq --raw-output .runtimes.compressed.prop)
 ipfs=$(echo $runtime | jq --raw-output .runtimes.compressed.ipfs)
 blake2_256=$(echo $runtime | jq --raw-output .runtimes.compressed.blake2_256)
 
+spec="$spec_name-$spec_version"
+extended="$impl_name-$impl_version.tx$transaction_version.au$authoring_version"
+
 cat <<-EOF
 \`\`\`
 Rust        : $rust
-Version     : $spec-$version ($impl_name-$impl_version.tx$transaction_version.au$authoring_version)
+Version     : $spec ($extended)
 Size        : $size
 Proposal    : $proposal
 IPFS        : $ipfs


### PR DESCRIPTION
A recent update of srtool updated the output for coreVersion to provide more information. This change will read the `specName` and `specVersion` fields to present a similar version to what we previously showed.

Will display `turing-284 (turing-1.tx10.au1)` instead of:

```
{
  "specName": "turing",
  "implName": "turing",
  "authoringVersion": 1,
  "specVersion": 284,
  "implVersion": 1,
  "apis": [
    [
      "0xdd718d5cc53262d4",
      1
    ],
    [
      "0xdf6acb689907609b",
      4
    ],
    [
      "0x37e397fc7c91f5e4",
      1
    ],
    [
      "0x40fe3ad401f8959a",
      6
    ],
    [
      "0xd2bc9897eed08f15",
      3
    ],
    [
      "0xf78b278be53f454c",
      2
    ],
    [
      "0xab3c0572291feb8b",
      1
    ],
    [
      "0xbc9d89904f5b923f",
      1
    ],
    [
      "0x37c8bb1350a9a2a8",
      1
    ],
    [
      "0x889fffe29b918d24",
      1
    ],
    [
      "0xea93e3f16f3d6962",
      2
    ]
  ],
  "transactionVersion": 10
}
```