### PR TITLE
forgot using abs val on downward scheduling

### DIFF
--- a/pallets/automation-price/src/lib.rs
+++ b/pallets/automation-price/src/lib.rs
@@ -794,7 +794,7 @@ pub mod pallet {
 					if last_asset_price < asset_target_price {
 						let last_asset_percentage =
 							Self::calculate_asset_percentage(last_asset_price, asset_target_price);
-						if trigger_percentage > last_asset_percentage {
+						if trigger_percentage < last_asset_percentage {
 							Err(Error::<T>::AssetNotInTriggerableRange)?
 						}
 					},


### PR DESCRIPTION
scheduling task with direction DOWN is failing currently because it believes that the asset is not in triggerable range. This is due to the fact that I forgot that calculate_asset_percentage uses absolute value to calculate the asset percentage and flipped the comparator for (trigger_percentage < last_asset_percentage) thinking it would come in a negative state should the last updated value be  lower than the baseline price. Therefore, if the last price update was lower than baseline price, then ANY downward scheduled task would fail due to `AssetNotInTriggerableRange`. This simple comparator flip should do the trick