### PR TITLE
Formalize scheduling variants

### DIFF
--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -498,30 +498,30 @@ benchmarks! {
 		schedule_notify_tasks::<T>(caller.clone(), vec![new_time_slot], T::MaxTasksPerSlot::get());
 	}: { AutomationTime::<T>::shift_missed_tasks(last_time_slot, diff) }
 
-	migration_v5 {
+	migration_add_schedule_to_task {
 		let v in 1..100;
 
-		use migrations::*;
+		use migrations::add_schedule_to_task::{AccountTasks as OldAccountTasks, AddScheduleToTask, OldAction, OldTask};
 		use frame_support::traits::OnRuntimeUpgrade;
 
 		for i in 0..v {
 			let account_id: T::AccountId = account("Account", 0, i);
 			let task_id_1 = Pallet::<T>::generate_task_id(account_id.clone(), vec![0]);
-			let task_1 = v5::OldTask::<T> {
+			let task_1 = OldTask::<T> {
 				owner_id: account_id.clone(),
 				provided_id: vec![1],
 				execution_times: vec![10].try_into().unwrap(),
 				executions_left: 1,
-				action: v5::OldAction::<T>::AutoCompoundDelegatedStake {
+				action: OldAction::<T>::AutoCompoundDelegatedStake {
 					delegator: account_id.clone(),
 					collator: account_id.clone(),
 					account_minimum: 100u32.into(),
 					frequency: 11,
 				},
 			};
-			v5::AccountTasks::<T>::insert(account_id.clone(), task_id_1, task_1);
+			OldAccountTasks::<T>::insert(account_id.clone(), task_id_1, task_1);
 		}
-	}: { v5::MigrateToV5::<T>::on_runtime_upgrade() }
+	}: { AddScheduleToTask::<T>::on_runtime_upgrade() }
 	verify {
 		assert_eq!(v, crate::AccountTasks::<T>::iter().count() as u32);
 	}

--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -506,8 +506,8 @@ benchmarks! {
 
 		for i in 0..v {
 			let account_id: T::AccountId = account("Account", 0, i);
-			let task_id_1 = Pallet::<T>::generate_task_id(account_id.clone(), vec![0]);
-			let task_1 = OldTask::<T> {
+			let task_id = Pallet::<T>::generate_task_id(account_id.clone(), vec![0]);
+			let task = OldTask::<T> {
 				owner_id: account_id.clone(),
 				provided_id: vec![1],
 				execution_times: vec![10].try_into().unwrap(),
@@ -519,7 +519,7 @@ benchmarks! {
 					frequency: 11,
 				},
 			};
-			OldAccountTasks::<T>::insert(account_id.clone(), task_id_1, task_1);
+			OldAccountTasks::<T>::insert(account_id.clone(), task_id, task);
 		}
 	}: { AddScheduleToTask::<T>::on_runtime_upgrade() }
 	verify {

--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -497,4 +497,32 @@ benchmarks! {
 
 		schedule_notify_tasks::<T>(caller.clone(), vec![new_time_slot], T::MaxTasksPerSlot::get());
 	}: { AutomationTime::<T>::shift_missed_tasks(last_time_slot, diff) }
+
+	migration_v5 {
+		let v in 1..100;
+
+		use migrations::*;
+		use frame_support::traits::OnRuntimeUpgrade;
+
+		for i in 0..v {
+			let account_id: T::AccountId = account("Account", 0, i);
+			let task_id_1 = Pallet::<T>::generate_task_id(account_id.clone(), vec![0]);
+			let task_1 = v5::OldTask::<T> {
+				owner_id: account_id.clone(),
+				provided_id: vec![1],
+				execution_times: vec![10].try_into().unwrap(),
+				executions_left: 1,
+				action: v5::OldAction::<T>::AutoCompoundDelegatedStake {
+					delegator: account_id.clone(),
+					collator: account_id.clone(),
+					account_minimum: 100u32.into(),
+					frequency: 11,
+				},
+			};
+			v5::AccountTasks::<T>::insert(account_id.clone(), task_id_1, task_1);
+		}
+	}: { v5::MigrateToV5::<T>::on_runtime_upgrade() }
+	verify {
+		assert_eq!(v, crate::AccountTasks::<T>::iter().count() as u32);
+	}
 }

--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -49,14 +49,14 @@ fn schedule_notify_tasks<T: Config>(owner: T::AccountId, times: Vec<u64>, count:
 
 	for _ in 0..count {
 		provided_id = increment_provided_id(provided_id);
-		let task = TaskOf::<T>::create_event_task(
+		let task = TaskOf::<T>::create_event_task::<T>(
 			owner.clone(),
 			provided_id.clone(),
-			times.clone().try_into().unwrap(),
+			times.clone(),
 			vec![4, 5, 6],
-		);
-		let task_id =
-			AutomationTime::<T>::schedule_task(&task, provided_id.clone(), times.clone()).unwrap();
+		)
+		.unwrap();
+		let task_id = AutomationTime::<T>::schedule_task(&task, provided_id.clone()).unwrap();
 		<AccountTasks<T>>::insert(owner.clone(), task_id, task);
 	}
 
@@ -72,15 +72,15 @@ fn schedule_transfer_tasks<T: Config>(owner: T::AccountId, time: u64, count: u32
 
 	for _ in 0..count {
 		provided_id = increment_provided_id(provided_id);
-		let task = TaskOf::<T>::create_native_transfer_task(
+		let task = TaskOf::<T>::create_native_transfer_task::<T>(
 			owner.clone(),
 			provided_id.clone(),
-			vec![time].try_into().unwrap(),
+			vec![time],
 			recipient.clone(),
 			amount.clone(),
-		);
-		let task_id =
-			AutomationTime::<T>::schedule_task(&task, provided_id.clone(), vec![time]).unwrap();
+		)
+		.unwrap();
+		let task_id = AutomationTime::<T>::schedule_task(&task, provided_id.clone()).unwrap();
 		<AccountTasks<T>>::insert(owner.clone(), task_id, task);
 	}
 
@@ -100,17 +100,17 @@ fn schedule_xcmp_tasks<T: Config>(owner: T::AccountId, times: Vec<u64>, count: u
 
 	for _ in 0..count {
 		provided_id = increment_provided_id(provided_id);
-		let task = TaskOf::<T>::create_xcmp_task(
+		let task = TaskOf::<T>::create_xcmp_task::<T>(
 			owner.clone(),
 			provided_id.clone(),
-			times.clone().try_into().unwrap(),
+			times.clone(),
 			para_id.clone().try_into().unwrap(),
 			T::GetNativeCurrencyId::get(),
 			vec![4, 5, 6],
 			5_000,
-		);
-		let task_id =
-			AutomationTime::<T>::schedule_task(&task, provided_id.clone(), times.clone()).unwrap();
+		)
+		.unwrap();
+		let task_id = AutomationTime::<T>::schedule_task(&task, provided_id.clone()).unwrap();
 		<AccountTasks<T>>::insert(owner.clone(), task_id, task);
 	}
 
@@ -133,15 +133,16 @@ fn schedule_auto_compound_delegated_stake_tasks<T: Config>(
 		);
 		let frequency = 3600;
 		let account_minimum = T::Currency::minimum_balance().saturating_mul(ED_MULTIPLIER.into());
-		let task = TaskOf::<T>::create_auto_compound_delegated_stake_task(
+		let task = TaskOf::<T>::create_auto_compound_delegated_stake_task::<T>(
 			owner.clone(),
 			provided_id.clone(),
 			time,
 			frequency,
 			collator,
 			account_minimum,
-		);
-		let task_id = AutomationTime::<T>::schedule_task(&task, provided_id, vec![time]).unwrap();
+		)
+		.unwrap();
+		let task_id = AutomationTime::<T>::schedule_task(&task, provided_id).unwrap();
 		<AccountTasks<T>>::insert(owner.clone(), task_id, task);
 		tasks.push((task_id, Pallet::<T>::get_account_task(owner.clone(), task_id).unwrap()));
 	}
@@ -342,7 +343,7 @@ benchmarks! {
 		T::DelegatorActions::setup_delegator(&collator, &delegator)?;
 
 		let (task_id, task) = schedule_auto_compound_delegated_stake_tasks::<T>(delegator.clone(), 3600, 1).pop().unwrap();
-	}: { AutomationTime::<T>::run_auto_compound_delegated_stake_task(delegator, collator, account_minimum, 3600, task_id, task) }
+	}: { AutomationTime::<T>::run_auto_compound_delegated_stake_task(delegator, collator, account_minimum, task_id, &task) }
 
 	run_dynamic_dispatch_action {
 		let caller: T::AccountId = account("caller", 0, SEED);
@@ -378,8 +379,8 @@ benchmarks! {
 
 		for i in 0..v {
 			let provided_id: Vec<u8> = vec![i.saturated_into::<u8>()];
-			let task = TaskOf::<T>::create_event_task(caller.clone(), provided_id.clone(), vec![time.into()].try_into().unwrap(), vec![4, 5, 6]);
-			let task_id = AutomationTime::<T>::schedule_task(&task, provided_id, vec![time.into()]).unwrap();
+			let task = TaskOf::<T>::create_event_task::<T>(caller.clone(), provided_id.clone(), vec![time.into()], vec![4, 5, 6]).unwrap();
+			let task_id = AutomationTime::<T>::schedule_task(&task, provided_id).unwrap();
 			let missed_task = MissedTaskV2Of::<T>::new(caller.clone(), task_id, time.into());
 			<AccountTasks<T>>::insert(caller.clone(), task_id, task);
 			missed_tasks.push(missed_task)
@@ -421,8 +422,8 @@ benchmarks! {
 
 		for i in 0..v {
 			let provided_id: Vec<u8> = vec![i.saturated_into::<u8>()];
-			let task = TaskOf::<T>::create_native_transfer_task(caller.clone(), provided_id.clone(), vec![time].try_into().unwrap(), recipient.clone(), transfer_amount.clone());
-			let task_id = AutomationTime::<T>::schedule_task(&task, provided_id, vec![time.into()]).unwrap();
+			let task = TaskOf::<T>::create_native_transfer_task::<T>(caller.clone(), provided_id.clone(), vec![time], recipient.clone(), transfer_amount.clone()).unwrap();
+			let task_id = AutomationTime::<T>::schedule_task(&task, provided_id).unwrap();
 			<AccountTasks<T>>::insert(caller.clone(), task_id, task);
 			task_ids.push((caller.clone(), task_id))
 		}
@@ -466,8 +467,8 @@ benchmarks! {
 			for j in 0..1 {
 				let time = time.saturating_add(3600);
 				let provided_id: Vec<u8> = vec![i.saturated_into::<u8>(), j.saturated_into::<u8>()];
-				let task = TaskOf::<T>::create_event_task(caller.clone(), provided_id.clone(), vec![time.into()].try_into().unwrap(), vec![4, 5, 6]);
-				let task_id = AutomationTime::<T>::schedule_task(&task, provided_id, vec![time.into()]).unwrap();
+				let task = TaskOf::<T>::create_event_task::<T>(caller.clone(), provided_id.clone(), vec![time.into()], vec![4, 5, 6]).unwrap();
+				let task_id = AutomationTime::<T>::schedule_task(&task, provided_id).unwrap();
 				<AccountTasks<T>>::insert(caller.clone(), task_id, task);
 			}
 		}
@@ -481,8 +482,8 @@ benchmarks! {
 
 		for i in 0..T::MaxTasksPerSlot::get() {
 			provided_id = increment_provided_id(provided_id);
-			let task = TaskOf::<T>::create_event_task(caller.clone(), provided_id.clone(), vec![current_time.into()].try_into().unwrap(), vec![4, 5, 6]);
-			let task_id = AutomationTime::<T>::schedule_task(&task, provided_id.clone(), vec![current_time.into()]).unwrap();
+			let task = TaskOf::<T>::create_event_task::<T>(caller.clone(), provided_id.clone(), vec![current_time.into()], vec![4, 5, 6]).unwrap();
+			let task_id = AutomationTime::<T>::schedule_task(&task, provided_id.clone()).unwrap();
 			<AccountTasks<T>>::insert(caller.clone(), task_id, task);
 		}
 	}: { AutomationTime::<T>::update_scheduled_task_queue(current_time, last_time_slot) }

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -234,8 +234,6 @@ pub mod pallet {
 		TooManyExecutionsTimes,
 		/// The call can no longer be decoded.
 		CallCannotBeDecoded,
-		/// Unsupported by pallet
-		UnsupportedOperation,
 	}
 
 	#[pallet::event]
@@ -1339,6 +1337,7 @@ pub mod pallet {
 						.ok_or(Error::<T>::InvalidTime)?;
 					*next_execution_time = new_execution_time;
 
+					// TODO: should execution fee depend on whether task is recurring?
 					T::FeeHandler::pay_checked_fees_for(&task.owner_id, &task.action, 1, || {
 						Self::insert_scheduled_tasks(task_id, task, vec![new_execution_time])
 							.map_err(|e| e.into())
@@ -1350,7 +1349,7 @@ pub mod pallet {
 					});
 					Ok(task)
 				},
-				Schedule::Fixed { .. } => Err(Error::<T>::UnsupportedOperation)?,
+				Schedule::Fixed { .. } => {},
 			}
 		}
 

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -362,11 +362,13 @@ pub mod pallet {
 				Err(Error::<T>::EmptyMessage)?
 			}
 
+			let schedule =
+				Schedule::<T::MaxExecutionTimes>::new_fixed_schedule::<T>(execution_times)?;
 			Self::validate_and_schedule_task(
 				Action::Notify { message },
 				who,
 				provided_id,
-				Schedule::<T::MaxExecutionTimes>::new_fixed_schedule::<T>(execution_times)?,
+				schedule,
 			)?;
 			Ok(().into())
 		}

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -1226,10 +1226,7 @@ pub mod pallet {
 		) -> Result<TaskId<T>, Error<T>> {
 			let owner_id = task.owner_id.clone();
 			let task_id = Self::generate_task_id(owner_id.clone(), provided_id.clone());
-			let execution_times = match &task.schedule {
-				Schedule::Fixed { execution_times } => execution_times.to_vec(),
-				Schedule::Recurring { next_execution_time, .. } => vec![*next_execution_time],
-			};
+			let execution_times = task.execution_times(vec![]);
 
 			if AccountTasks::<T>::contains_key(owner_id.clone(), task_id) {
 				Err(Error::<T>::DuplicateTask)?;

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -494,8 +494,10 @@ pub mod pallet {
 				collator: collator_id,
 				account_minimum,
 			};
-			let schedule =
-				Schedule::<T::MaxExecutionTimes>::new_recurring_schedule(execution_time, frequency);
+			let schedule = Schedule::<T::MaxExecutionTimes>::new_recurring_schedule::<T>(
+				execution_time,
+				frequency,
+			)?;
 			Self::validate_and_schedule_task(action, who, provided_id, schedule)?;
 			Ok(().into())
 		}
@@ -1278,7 +1280,6 @@ pub mod pallet {
 				Err(Error::<T>::EmptyProvidedId)?
 			}
 
-			schedule.valid::<T>()?;
 			let executions = schedule.number_of_known_executions();
 
 			let task =

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -1125,7 +1125,7 @@ pub mod pallet {
 		/// Removes the task of the provided task_id and all scheduled tasks, including those in the task queue.
 		fn remove_task(task_id: TaskId<T>, task: TaskOf<T>) {
 			let mut found_task: bool = false;
-			let mut execution_times = task.execution_times(vec![]);
+			let mut execution_times = task.execution_times();
 			Self::clean_execution_times_vector(&mut execution_times);
 			let current_time_slot = match Self::get_current_time_slot() {
 				Ok(time_slot) => time_slot,
@@ -1226,7 +1226,7 @@ pub mod pallet {
 		) -> Result<TaskId<T>, Error<T>> {
 			let owner_id = task.owner_id.clone();
 			let task_id = Self::generate_task_id(owner_id.clone(), provided_id.clone());
-			let execution_times = task.execution_times(vec![]);
+			let execution_times = task.execution_times();
 
 			if AccountTasks::<T>::contains_key(owner_id.clone(), task_id) {
 				Err(Error::<T>::DuplicateTask)?;

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -1107,9 +1107,8 @@ pub mod pallet {
 		/// Removes the task of the provided task_id and all scheduled tasks, including those in the task queue.
 		fn remove_task(task_id: TaskId<T>, task: TaskOf<T>) {
 			let mut found_task: bool = false;
-			Self::clean_execution_times_vector(
-				&mut task.execution_times().expect("TODO: always Schedule::Fixed for now").to_vec(),
-			);
+			let mut execution_times = task.execution_times(vec![]);
+			Self::clean_execution_times_vector(&mut execution_times);
 			let current_time_slot = match Self::get_current_time_slot() {
 				Ok(time_slot) => time_slot,
 				// This will only occur for the first block in the chain.
@@ -1117,12 +1116,7 @@ pub mod pallet {
 			};
 
 			if let Some((last_time_slot, _)) = Self::get_last_slot() {
-				for execution_time in task
-					.execution_times()
-					.expect("TODO: always Schedule::Fixed for now")
-					.iter()
-					.rev()
-				{
+				for execution_time in execution_times.iter().rev() {
 					// Execution time is less than current time slot and in the past.  No more execution times need to be removed.
 					if *execution_time < current_time_slot {
 						break
@@ -1170,12 +1164,7 @@ pub mod pallet {
 				}
 			} else {
 				// If last time slot does not exist then check each time in scheduled tasks and remove if exists.
-				for execution_time in task
-					.execution_times()
-					.expect("TODO: always Schedule::Fixed for now")
-					.iter()
-					.rev()
-				{
+				for execution_time in execution_times.iter().rev() {
 					if let Some(ScheduledTasksOf::<T> { tasks: mut account_task_ids, weight }) =
 						Self::get_scheduled_tasks(*execution_time)
 					{

--- a/pallets/automation-time/src/migrations/mod.rs
+++ b/pallets/automation-time/src/migrations/mod.rs
@@ -2,4 +2,4 @@
 
 // mod old;
 
-pub mod v5;
+pub mod add_schedule_to_task;

--- a/pallets/automation-time/src/migrations/mod.rs
+++ b/pallets/automation-time/src/migrations/mod.rs
@@ -1,3 +1,5 @@
 // Migrations
 
 // mod old;
+
+pub mod v5;

--- a/pallets/automation-time/src/migrations/v5.rs
+++ b/pallets/automation-time/src/migrations/v5.rs
@@ -1,0 +1,157 @@
+use core::marker::PhantomData;
+
+use crate::{
+	AccountOf, ActionOf, BalanceOf, Config, Schedule, Seconds, TaskId, TaskOf, UnixTime, Vec,
+};
+use codec::{Decode, Encode};
+use cumulus_primitives_core::ParaId;
+use frame_support::{
+	traits::{Get, OnRuntimeUpgrade},
+	weights::Weight,
+	BoundedVec, Twox64Concat,
+};
+use scale_info::TypeInfo;
+
+#[derive(Debug, Encode, Decode, TypeInfo)]
+#[scale_info(skip_type_params(MaxExecutionTimes))]
+pub struct OldTask<T: Config> {
+	pub owner_id: T::AccountId,
+	pub provided_id: Vec<u8>,
+	pub execution_times: BoundedVec<UnixTime, T::MaxExecutionTimes>,
+	pub executions_left: u32,
+	pub action: OldAction<T>,
+}
+
+impl<T: Config> From<OldTask<T>> for TaskOf<T> {
+	fn from(task: OldTask<T>) -> Self {
+		let schedule = match task.action {
+			OldAction::AutoCompoundDelegatedStake { frequency, .. } => Schedule::Recurring {
+				next_execution_time: *task.execution_times.last().expect("Atleast one execution"),
+				frequency,
+			},
+			_ => Schedule::Fixed {
+				execution_times: task.execution_times,
+				executions_left: task.executions_left,
+			},
+		};
+		TaskOf::<T> {
+			owner_id: task.owner_id,
+			provided_id: task.provided_id,
+			action: task.action.into(),
+			schedule,
+		}
+	}
+}
+
+/// The enum that stores all action specific data.
+#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, TypeInfo)]
+pub enum OldAction<T: Config> {
+	Notify {
+		message: Vec<u8>,
+	},
+	NativeTransfer {
+		sender: T::AccountId,
+		recipient: T::AccountId,
+		amount: BalanceOf<T>,
+	},
+	XCMP {
+		para_id: ParaId,
+		currency_id: T::CurrencyId,
+		encoded_call: Vec<u8>,
+		encoded_call_weight: Weight,
+	},
+	AutoCompoundDelegatedStake {
+		delegator: T::AccountId,
+		collator: T::AccountId,
+		account_minimum: BalanceOf<T>,
+		frequency: Seconds,
+	},
+	DynamicDispatch {
+		encoded_call: Vec<u8>,
+	},
+}
+
+impl<T: Config> From<OldAction<T>> for ActionOf<T> {
+	fn from(action: OldAction<T>) -> Self {
+		match action {
+			OldAction::AutoCompoundDelegatedStake {
+				delegator, collator, account_minimum, ..
+			} => Self::AutoCompoundDelegatedStake { delegator, collator, account_minimum },
+			OldAction::Notify { message } => Self::Notify { message },
+			OldAction::NativeTransfer { sender, recipient, amount } =>
+				Self::NativeTransfer { sender, recipient, amount },
+			OldAction::XCMP { para_id, currency_id, encoded_call, encoded_call_weight } =>
+				Self::XCMP { para_id, currency_id, encoded_call, encoded_call_weight },
+			OldAction::DynamicDispatch { encoded_call } => Self::DynamicDispatch { encoded_call },
+		}
+	}
+}
+
+#[frame_support::storage_alias]
+type AccountTasks<T: Config> = StorageDoubleMap<
+	AutomationTime,
+	Twox64Concat,
+	AccountOf<T>,
+	Twox64Concat,
+	TaskId<T>,
+	OldTask<T>,
+>;
+
+pub struct MigrateToV5<T>(PhantomData<T>);
+impl<T: Config> OnRuntimeUpgrade for MigrateToV5<T> {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		use frame_support::traits::OnRuntimeUpgradeHelpersExt;
+
+		let task_count = AccountTasks::<T>::iter().count();
+		Self::set_temp_storage::<u32>(task_count as u32, "pre_migration_task_count");
+
+		log::info!(
+			target: "automation-time",
+			"migration: AutomationTime storage version v5 PRE migration checks succesful!"
+		);
+
+		Ok(())
+	}
+
+	fn on_runtime_upgrade() -> Weight {
+		log::info!(target: "automation-time", "Migrating automation-time v5");
+
+		let mut migrated_tasks = 0u64;
+		AccountTasks::<T>::iter().for_each(|(account_id, task_id, task)| {
+			let migrated_task: TaskOf<T> = task.into();
+			crate::AccountTasks::<T>::insert(account_id, task_id, migrated_task);
+
+			migrated_tasks += 1;
+		});
+
+		log::info!(
+			target: "automation-time",
+			"migration: AutomationTime storage version v5 migration succesful! Migrated {} tasks.",
+			migrated_tasks
+		);
+
+		// 1 read + write to transform each task
+		let weight = T::DbWeight::get().reads_writes(migrated_tasks, migrated_tasks);
+
+		// Adding a buffer for the rest of the code
+		weight + (migrated_tasks * 10_000_000)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		use frame_support::traits::OnRuntimeUpgradeHelpersExt;
+
+		let post_task_count = crate::AccountTasks::<T>::iter().count() as u32;
+		let pre_task_count = Self::get_temp_storage::<u32>("pre_migration_task_count").unwrap();
+		assert_eq!(post_task_count, pre_task_count);
+
+		log::info!(
+			target: "automation-time",
+			"migration: AutomationTime storage version v5 POST migration checks succesful! Migrated {} tasks.",
+			post_task_count
+		);
+
+		Ok(())
+	}
+}

--- a/pallets/automation-time/src/migrations/v5.rs
+++ b/pallets/automation-time/src/migrations/v5.rs
@@ -8,6 +8,7 @@ use codec::{Decode, Encode};
 use cumulus_primitives_core::ParaId;
 use frame_support::{traits::OnRuntimeUpgrade, weights::Weight, BoundedVec, Twox64Concat};
 use scale_info::TypeInfo;
+use sp_std::vec::Vec;
 
 #[derive(Debug, Encode, Decode, TypeInfo)]
 #[scale_info(skip_type_params(MaxExecutionTimes))]

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -348,7 +348,29 @@ pub fn add_task_to_task_queue(
 	scheduled_times: Vec<u64>,
 	action: ActionOf<Test>,
 ) -> sp_core::H256 {
-	let task_id = create_task(owner, provided_id, scheduled_times, action);
+	let schedule =
+		Schedule::<MaxExecutionTimes>::new_fixed_schedule::<Test>(scheduled_times).unwrap();
+	add_to_task_queue(owner, provided_id, schedule, action)
+}
+
+pub fn add_recurring_task_to_task_queue(
+	owner: [u8; 32],
+	provided_id: Vec<u8>,
+	scheduled_time: u64,
+	frequency: u64,
+	action: ActionOf<Test>,
+) -> sp_core::H256 {
+	let schedule = Schedule::<MaxExecutionTimes>::new_recurring_schedule(scheduled_time, frequency);
+	add_to_task_queue(owner, provided_id, schedule, action)
+}
+
+pub fn add_to_task_queue(
+	owner: [u8; 32],
+	provided_id: Vec<u8>,
+	schedule: Schedule<MaxExecutionTimes>,
+	action: ActionOf<Test>,
+) -> sp_core::H256 {
+	let task_id = create_task(owner, provided_id, schedule, action);
 	let mut task_queue = AutomationTime::get_task_queue();
 	task_queue.push((AccountId32::new(owner), task_id));
 	TaskQueueV2::<Test>::put(task_queue);
@@ -361,7 +383,9 @@ pub fn add_task_to_missed_queue(
 	scheduled_times: Vec<u64>,
 	action: ActionOf<Test>,
 ) -> sp_core::H256 {
-	let task_id = create_task(owner, provided_id, scheduled_times.clone(), action);
+	let schedule =
+		Schedule::<MaxExecutionTimes>::new_fixed_schedule::<Test>(scheduled_times.clone()).unwrap();
+	let task_id = create_task(owner, provided_id, schedule, action);
 	let missed_task =
 		MissedTaskV2Of::<Test>::new(AccountId32::new(owner), task_id, scheduled_times[0]);
 	let mut missed_queue = AutomationTime::get_missed_queue();
@@ -373,13 +397,12 @@ pub fn add_task_to_missed_queue(
 pub fn create_task(
 	owner: [u8; 32],
 	provided_id: Vec<u8>,
-	scheduled_times: Vec<u64>,
+	schedule: Schedule<MaxExecutionTimes>,
 	action: ActionOf<Test>,
 ) -> sp_core::H256 {
 	let task_hash_input = TaskHashInput::new(AccountId32::new(owner), provided_id.clone());
 	let task_id = BlakeTwo256::hash_of(&task_hash_input);
-	let task =
-		TaskOf::<Test>::new(owner.into(), provided_id, scheduled_times.try_into().unwrap(), action);
+	let task = TaskOf::<Test>::new(owner.into(), provided_id, schedule, action);
 	AccountTasks::<Test>::insert(AccountId::new(owner), task_id, task);
 	task_id
 }

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -363,7 +363,9 @@ pub fn add_recurring_task_to_task_queue(
 	frequency: u64,
 	action: ActionOf<Test>,
 ) -> sp_core::H256 {
-	let schedule = Schedule::<MaxExecutionTimes>::new_recurring_schedule(scheduled_time, frequency);
+	let schedule =
+		Schedule::<MaxExecutionTimes>::new_recurring_schedule::<Test>(scheduled_time, frequency)
+			.unwrap();
 	add_to_task_queue(owner, provided_id, schedule, action)
 }
 

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -237,6 +237,9 @@ impl<Test: frame_system::Config> pallet_automation_time::WeightInfo for MockWeig
 	fn shift_missed_tasks() -> Weight {
 		20_000
 	}
+	fn migration_v5(_: u32) -> Weight {
+		0
+	}
 }
 
 pub struct DealWithExecutionFees<R>(sp_std::marker::PhantomData<R>);

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -237,7 +237,7 @@ impl<Test: frame_system::Config> pallet_automation_time::WeightInfo for MockWeig
 	fn shift_missed_tasks() -> Weight {
 		20_000
 	}
-	fn migration_v5(_: u32) -> Weight {
+	fn migration_add_schedule_to_task(_: u32) -> Weight {
 		0
 	}
 }

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -582,7 +582,7 @@ fn cancel_works_for_an_executed_task() {
 				panic!("A task should exist if it was scheduled")
 			},
 			Some(task) => {
-				assert_eq!(task.executions_left(), 2);
+				assert_eq!(task.schedule.number_of_known_executions(), 2);
 			},
 		}
 
@@ -612,7 +612,7 @@ fn cancel_works_for_an_executed_task() {
 				panic!("A task should exist if it was scheduled")
 			},
 			Some(task) => {
-				assert_eq!(task.executions_left(), 1);
+				assert_eq!(task.schedule.number_of_known_executions(), 1);
 			},
 		}
 
@@ -1192,7 +1192,7 @@ fn missed_tasks_updates_executions_left() {
 				panic!("A task should exist if it was scheduled")
 			},
 			Some(task) => {
-				assert_eq!(task.executions_left(), 2);
+				assert_eq!(task.schedule.number_of_known_executions(), 2);
 			},
 		}
 		match AutomationTime::get_account_task(owner.clone(), task_id2) {
@@ -1200,7 +1200,7 @@ fn missed_tasks_updates_executions_left() {
 				panic!("A task should exist if it was scheduled")
 			},
 			Some(task) => {
-				assert_eq!(task.executions_left(), 2);
+				assert_eq!(task.schedule.number_of_known_executions(), 2);
 			},
 		}
 
@@ -1229,7 +1229,7 @@ fn missed_tasks_updates_executions_left() {
 				panic!("A task should exist if it was scheduled")
 			},
 			Some(task) => {
-				assert_eq!(task.executions_left(), 1);
+				assert_eq!(task.schedule.number_of_known_executions(), 1);
 			},
 		}
 		match AutomationTime::get_account_task(owner.clone(), task_id2) {
@@ -1237,7 +1237,7 @@ fn missed_tasks_updates_executions_left() {
 				panic!("A task should exist if it was scheduled")
 			},
 			Some(task) => {
-				assert_eq!(task.executions_left(), 1);
+				assert_eq!(task.schedule.number_of_known_executions(), 1);
 			},
 		}
 	})
@@ -1266,7 +1266,7 @@ fn missed_tasks_removes_completed_tasks() {
 				panic!("A task should exist if it was scheduled")
 			},
 			Some(task) => {
-				assert_eq!(task.executions_left(), 2);
+				assert_eq!(task.schedule.number_of_known_executions(), 2);
 			},
 		}
 
@@ -1453,7 +1453,7 @@ fn auto_compound_delegated_stake_reschedules_and_reruns() {
 			.expect("Task should have been rescheduled");
 		let task = AutomationTime::get_account_task(AccountId32::new(ALICE), task_id)
 			.expect("Task should not have been removed from task map");
-		assert_eq!(task.executions_left(), 1);
+		assert_eq!(task.schedule.number_of_known_executions(), 1);
 		assert_eq!(task.execution_times(), vec![next_scheduled_time]);
 
 		Timestamp::set_timestamp(next_scheduled_time * 1_000);
@@ -1570,7 +1570,7 @@ fn trigger_tasks_updates_executions_left() {
 				panic!("A task should exist if it was scheduled")
 			},
 			Some(task) => {
-				assert_eq!(task.executions_left(), 2);
+				assert_eq!(task.schedule.number_of_known_executions(), 2);
 			},
 		}
 
@@ -1588,7 +1588,7 @@ fn trigger_tasks_updates_executions_left() {
 				panic!("A task should exist if it was scheduled")
 			},
 			Some(task) => {
-				assert_eq!(task.executions_left(), 1);
+				assert_eq!(task.schedule.number_of_known_executions(), 1);
 			},
 		}
 	})
@@ -1611,7 +1611,7 @@ fn trigger_tasks_removes_completed_tasks() {
 				panic!("A task should exist if it was scheduled")
 			},
 			Some(task) => {
-				assert_eq!(task.executions_left(), 1);
+				assert_eq!(task.schedule.number_of_known_executions(), 1);
 			},
 		}
 

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -1368,7 +1368,6 @@ fn trigger_tasks_completes_auto_compound_delegated_stake_task() {
 				delegator: AccountId32::new(ALICE),
 				collator: AccountId32::new(BOB),
 				account_minimum,
-				frequency: 3600,
 			},
 		);
 
@@ -1411,15 +1410,15 @@ fn auto_compound_delegated_stake_reschedules_and_reruns() {
 		let account_minimum = before_balance / 2;
 		let frequency = 3_600;
 
-		let task_id = add_task_to_task_queue(
+		let task_id = add_recurring_task_to_task_queue(
 			ALICE,
 			vec![1],
-			vec![SCHEDULED_TIME],
+			SCHEDULED_TIME,
+			frequency,
 			Action::AutoCompoundDelegatedStake {
 				delegator: AccountId32::new(ALICE),
 				collator: AccountId32::new(BOB),
 				account_minimum,
-				frequency,
 			},
 		);
 
@@ -1478,7 +1477,6 @@ fn auto_compound_delegated_stake_without_minimum_balance() {
 				delegator: AccountId32::new(ALICE),
 				collator: AccountId32::new(BOB),
 				account_minimum,
-				frequency: 3600,
 			},
 		);
 
@@ -1509,15 +1507,15 @@ fn auto_compound_delegated_stake_does_not_reschedule_on_failure() {
 		let account_minimum = before_balance * 2;
 		let frequency = 3_600;
 
-		let task_id = add_task_to_task_queue(
+		let task_id = add_recurring_task_to_task_queue(
 			ALICE,
 			vec![1],
-			vec![SCHEDULED_TIME],
+			SCHEDULED_TIME,
+			frequency,
 			Action::AutoCompoundDelegatedStake {
 				delegator: AccountId32::new(ALICE),
 				collator: AccountId32::new(BOB),
 				account_minimum,
-				frequency,
 			},
 		);
 

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -1454,7 +1454,7 @@ fn auto_compound_delegated_stake_reschedules_and_reruns() {
 		let task = AutomationTime::get_account_task(AccountId32::new(ALICE), task_id)
 			.expect("Task should not have been removed from task map");
 		assert_eq!(task.executions_left(), 1);
-		assert_eq!(task.execution_times(vec![]), vec![next_scheduled_time]);
+		assert_eq!(task.execution_times(), vec![next_scheduled_time]);
 
 		Timestamp::set_timestamp(next_scheduled_time * 1_000);
 		get_funds(AccountId32::new(ALICE));

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -1443,7 +1443,7 @@ fn auto_compound_delegated_stake_reschedules_and_reruns() {
 		let task = AutomationTime::get_account_task(AccountId32::new(ALICE), task_id)
 			.expect("Task should not have been removed from task map");
 		assert_eq!(task.executions_left, 1);
-		assert_eq!(task.execution_times().unwrap().to_vec(), vec![next_scheduled_time]);
+		assert_eq!(task.execution_times(vec![]), vec![next_scheduled_time]);
 
 		Timestamp::set_timestamp(next_scheduled_time * 1_000);
 		get_funds(AccountId32::new(ALICE));

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -774,7 +774,7 @@ mod run_dynamic_dispatch_action {
 			let task_id = AutomationTime::generate_task_id(account_id.clone(), vec![1]);
 			let bad_encoded_call: Vec<u8> = vec![1];
 
-			let weight = AutomationTime::run_dynamic_dispatch_action(
+			let (weight, _) = AutomationTime::run_dynamic_dispatch_action(
 				account_id.clone(),
 				bad_encoded_call,
 				task_id,

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -1444,7 +1444,7 @@ fn auto_compound_delegated_stake_reschedules_and_reruns() {
 		let task = AutomationTime::get_account_task(AccountId32::new(ALICE), task_id)
 			.expect("Task should not have been removed from task map");
 		assert_eq!(task.executions_left, 1);
-		assert_eq!(task.execution_times.to_vec(), vec![next_scheduled_time]);
+		assert_eq!(task.execution_times().unwrap().to_vec(), vec![next_scheduled_time]);
 
 		Timestamp::set_timestamp(next_scheduled_time * 1_000);
 		get_funds(AccountId32::new(ALICE));

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -29,8 +29,8 @@ use sp_runtime::{
 	AccountId32,
 };
 
-const START_BLOCK_TIME: u64 = 33198768000 * 1_000;
-const SCHEDULED_TIME: u64 = START_BLOCK_TIME / 1_000 + 7200;
+pub const START_BLOCK_TIME: u64 = 33198768000 * 1_000;
+pub const SCHEDULED_TIME: u64 = START_BLOCK_TIME / 1_000 + 7200;
 const LAST_BLOCK_TIME: u64 = START_BLOCK_TIME / 1_000;
 
 #[test]
@@ -959,8 +959,12 @@ fn trigger_tasks_handles_missed_slots() {
 #[test]
 fn trigger_tasks_limits_missed_slots() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
-		let missing_task_id0 =
-			add_task_to_task_queue(ALICE, vec![40], vec![0], Action::Notify { message: vec![40] });
+		let missing_task_id0 = add_task_to_task_queue(
+			ALICE,
+			vec![40],
+			vec![SCHEDULED_TIME],
+			Action::Notify { message: vec![40] },
+		);
 		assert_eq!(AutomationTime::get_missed_queue().len(), 0);
 		Timestamp::set_timestamp((SCHEDULED_TIME - 25200) * 1_000);
 		let missing_task_id1 =
@@ -1042,14 +1046,14 @@ fn trigger_tasks_completes_all_tasks() {
 		let task_id1 = add_task_to_task_queue(
 			ALICE,
 			vec![40],
-			vec![0],
+			vec![SCHEDULED_TIME],
 			Action::Notify { message: message_one.clone() },
 		);
 		let message_two: Vec<u8> = vec![2, 4];
 		let task_id2 = add_task_to_task_queue(
 			ALICE,
 			vec![50],
-			vec![0],
+			vec![SCHEDULED_TIME],
 			Action::Notify { message: message_two.clone() },
 		);
 		LastTimeSlot::<Test>::put((LAST_BLOCK_TIME, LAST_BLOCK_TIME));
@@ -1100,14 +1104,14 @@ fn trigger_tasks_completes_some_tasks() {
 		let task_id1 = add_task_to_task_queue(
 			ALICE,
 			vec![40],
-			vec![0],
+			vec![SCHEDULED_TIME],
 			Action::Notify { message: message_one.clone() },
 		);
 		let message_two: Vec<u8> = vec![2, 4];
 		let task_id2 = add_task_to_task_queue(
 			ALICE,
 			vec![50],
-			vec![0],
+			vec![SCHEDULED_TIME],
 			Action::Notify { message: message_two.clone() },
 		);
 		LastTimeSlot::<Test>::put((LAST_BLOCK_TIME, LAST_BLOCK_TIME));
@@ -1131,13 +1135,13 @@ fn trigger_tasks_completes_all_missed_tasks() {
 		let task_id1 = add_task_to_missed_queue(
 			ALICE,
 			vec![40],
-			vec![0],
+			vec![SCHEDULED_TIME],
 			Action::Notify { message: vec![40] },
 		);
 		let task_id2 = add_task_to_missed_queue(
 			ALICE,
 			vec![50],
-			vec![0],
+			vec![SCHEDULED_TIME],
 			Action::Notify { message: vec![40] },
 		);
 		LastTimeSlot::<Test>::put((LAST_BLOCK_TIME, LAST_BLOCK_TIME));
@@ -1150,12 +1154,12 @@ fn trigger_tasks_completes_all_missed_tasks() {
 				Event::AutomationTime(crate::Event::TaskMissed {
 					who: AccountId32::new(ALICE),
 					task_id: task_id1,
-					execution_time: 0
+					execution_time: SCHEDULED_TIME
 				}),
 				Event::AutomationTime(crate::Event::TaskMissed {
 					who: AccountId32::new(ALICE),
 					task_id: task_id2,
-					execution_time: 0
+					execution_time: SCHEDULED_TIME
 				}),
 			]
 		);
@@ -1632,18 +1636,22 @@ fn on_init_runs_tasks() {
 		let task_id1 = add_task_to_task_queue(
 			ALICE,
 			vec![40],
-			vec![0],
+			vec![SCHEDULED_TIME],
 			Action::Notify { message: message_one.clone() },
 		);
 		let message_two: Vec<u8> = vec![2, 4];
 		let task_id2 = add_task_to_task_queue(
 			ALICE,
 			vec![50],
-			vec![0],
+			vec![SCHEDULED_TIME],
 			Action::Notify { message: message_two.clone() },
 		);
-		let task_id3 =
-			add_task_to_task_queue(ALICE, vec![60], vec![0], Action::Notify { message: vec![50] });
+		let task_id3 = add_task_to_task_queue(
+			ALICE,
+			vec![60],
+			vec![SCHEDULED_TIME],
+			Action::Notify { message: vec![50] },
+		);
 		LastTimeSlot::<Test>::put((LAST_BLOCK_TIME, LAST_BLOCK_TIME));
 
 		AutomationTime::on_initialize(1);

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -1360,10 +1360,11 @@ fn trigger_tasks_completes_auto_compound_delegated_stake_task() {
 		let before_balance = Balances::free_balance(AccountId32::new(ALICE));
 		let account_minimum = before_balance / 2;
 
-		let task_id = add_task_to_task_queue(
+		let task_id = add_recurring_task_to_task_queue(
 			ALICE,
 			vec![1],
-			vec![SCHEDULED_TIME],
+			SCHEDULED_TIME,
+			3600,
 			Action::AutoCompoundDelegatedStake {
 				delegator: AccountId32::new(ALICE),
 				collator: AccountId32::new(BOB),

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -257,10 +257,7 @@ impl<AccountId: Clone, Balance, CurrencyId, MaxExecutionTimes: Get<u32>>
 	}
 
 	pub fn executions_left(&self) -> u32 {
-		match &self.schedule {
-			Schedule::Fixed { executions_left, .. } => *executions_left,
-			Schedule::Recurring { .. } => 1,
-		}
+		*&self.schedule.number_of_known_executions()
 	}
 }
 

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -111,8 +111,9 @@ impl<B: Get<u32>> PartialEq for Schedule<B> {
 }
 
 impl<MaxExecutionTimes: Get<u32>> Schedule<MaxExecutionTimes> {
-	pub fn new_fixed_schedule<T: Config>(execution_times: Vec<UnixTime>) -> Result<Self, Error<T>> {
-		let mut execution_times = execution_times.clone();
+	pub fn new_fixed_schedule<T: Config>(
+		mut execution_times: Vec<UnixTime>,
+	) -> Result<Self, Error<T>> {
 		Pallet::<T>::clean_execution_times_vector(&mut execution_times);
 		let executions_left = execution_times.len() as u32;
 		let execution_times: BoundedVec<UnixTime, MaxExecutionTimes> =

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -97,9 +97,12 @@ pub enum Schedule<MaxExecutionTimes: Get<u32>> {
 impl<B: Get<u32>> PartialEq for Schedule<B> {
 	fn eq(&self, other: &Self) -> bool {
 		match (self, other) {
-			(Schedule::Fixed { execution_times: a }, Schedule::Fixed { execution_times: b }) =>
-				a.to_vec() == b.to_vec(),
-			(Schedule::Recurring { .. }, Schedule::Recurring { .. }) => self == other,
+			(Schedule::Fixed { execution_times: t1 }, Schedule::Fixed { execution_times: t2 }) =>
+				t1.to_vec() == t2.to_vec(),
+			(
+				Schedule::Recurring { next_execution_time: t1, frequency: f1 },
+				Schedule::Recurring { next_execution_time: t2, frequency: f2 },
+			) => t1 == t2 && f1 == f2,
 			_ => false,
 		}
 	}

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -256,12 +256,11 @@ impl<AccountId: Clone, Balance, CurrencyId, MaxExecutionTimes: Get<u32>>
 		Ok(Self::new(owner_id, provided_id, schedule, action))
 	}
 
-	pub fn execution_times(&self, mut l: Vec<UnixTime>) -> Vec<UnixTime> {
+	pub fn execution_times(&self) -> Vec<UnixTime> {
 		match &self.schedule {
 			Schedule::Fixed { execution_times, .. } => execution_times.to_vec(),
 			Schedule::Recurring { next_execution_time, .. } => {
-				l.push(*next_execution_time);
-				l
+				vec![*next_execution_time]
 			},
 		}
 	}

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -560,6 +560,7 @@ mod tests {
 					frequency: 3600
 				}
 				.valid::<Test>());
+				// Next execution time not at hour granuality
 				assert_err!(
 					Schedule::<MaxExecutionTimes>::Recurring {
 						next_execution_time: start_time + 3650,
@@ -568,6 +569,16 @@ mod tests {
 					.valid::<Test>(),
 					Error::<Test>::InvalidTime
 				);
+				// Frequency not at hour granularity
+				assert_err!(
+					Schedule::<MaxExecutionTimes>::Recurring {
+						next_execution_time: start_time + 3650,
+						frequency: 3650
+					}
+					.valid::<Test>(),
+					Error::<Test>::InvalidTime
+				);
+				// Frequency of 0
 				assert_err!(
 					Schedule::<MaxExecutionTimes>::Recurring {
 						next_execution_time: start_time + 3600,
@@ -576,6 +587,7 @@ mod tests {
 					.valid::<Test>(),
 					Error::<Test>::InvalidTime
 				);
+				// Frequency too far out
 				assert_err!(
 					Schedule::<MaxExecutionTimes>::Recurring {
 						next_execution_time: start_time + 3600,

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -264,10 +264,6 @@ impl<AccountId: Clone, Balance, CurrencyId, MaxExecutionTimes: Get<u32>>
 			},
 		}
 	}
-
-	pub fn executions_left(&self) -> u32 {
-		*&self.schedule.number_of_known_executions()
-	}
 }
 
 #[derive(Debug, Eq, PartialEq, Encode, Decode, TypeInfo)]

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -184,11 +184,7 @@ impl<AccountId: Clone, Balance, CurrencyId, MaxExecutionTimes: Get<u32>>
 		schedule: Schedule<MaxExecutionTimes>,
 		action: Action<AccountId, Balance, CurrencyId>,
 	) -> Self {
-		// TODO: executions_left
-		let executions_left: u32 = match schedule {
-			Schedule::Fixed { ref execution_times } => execution_times.len().try_into().unwrap(),
-			Schedule::Recurring { .. } => 1,
-		};
+		let executions_left: u32 = schedule.number_of_known_executions();
 		Self { owner_id, provided_id, schedule, executions_left, action }
 	}
 
@@ -247,10 +243,13 @@ impl<AccountId: Clone, Balance, CurrencyId, MaxExecutionTimes: Get<u32>>
 		Self::new(owner_id, provided_id, schedule, action)
 	}
 
-	pub fn execution_times(&self) -> Option<&BoundedVec<UnixTime, MaxExecutionTimes>> {
+	pub fn execution_times(&self, mut l: Vec<UnixTime>) -> Vec<UnixTime> {
 		match &self.schedule {
-			Schedule::Fixed { execution_times } => Some(execution_times),
-			Schedule::Recurring { .. } => None,
+			Schedule::Fixed { execution_times } => execution_times.to_vec(),
+			Schedule::Recurring { next_execution_time, .. } => {
+				l.push(*next_execution_time);
+				l
+			},
 		}
 	}
 }

--- a/pallets/automation-time/src/weights.rs
+++ b/pallets/automation-time/src/weights.rs
@@ -105,6 +105,7 @@ pub trait WeightInfo {
 	fn append_to_missed_tasks(v: u32, ) -> Weight;
 	fn update_scheduled_task_queue() -> Weight;
 	fn shift_missed_tasks() -> Weight;
+	fn migration_v5(v: u32, ) -> Weight;
 }
 
 /// Weights for pallet_automation_time using the Substrate node and recommended hardware.
@@ -319,6 +320,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
+	// Storage: AutomationTime AccountTasks (r:2 w:1)
+	/// The range of component `v` is `[1, 100]`.
+	fn migration_v5(v: u32, ) -> Weight {
+		(0 as Weight)
+			// Standard Error: 10_000
+			.saturating_add((8_680_000 as Weight).saturating_mul(v as Weight))
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(v as Weight)))
+	}
 }
 
 // For backwards compatibility and tests
@@ -531,5 +542,15 @@ impl WeightInfo for () {
 		(29_532_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+	}
+	// Storage: AutomationTime AccountTasks (r:2 w:1)
+	/// The range of component `v` is `[1, 100]`.
+	fn migration_v5(v: u32, ) -> Weight {
+		(0 as Weight)
+			// Standard Error: 10_000
+			.saturating_add((8_680_000 as Weight).saturating_mul(v as Weight))
+			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(v as Weight)))
+			.saturating_add(RocksDbWeight::get().writes((1 as Weight).saturating_mul(v as Weight)))
 	}
 }

--- a/pallets/automation-time/src/weights.rs
+++ b/pallets/automation-time/src/weights.rs
@@ -105,7 +105,7 @@ pub trait WeightInfo {
 	fn append_to_missed_tasks(v: u32, ) -> Weight;
 	fn update_scheduled_task_queue() -> Weight;
 	fn shift_missed_tasks() -> Weight;
-	fn migration_v5(v: u32, ) -> Weight;
+	fn migration_add_schedule_to_task(v: u32, ) -> Weight;
 }
 
 /// Weights for pallet_automation_time using the Substrate node and recommended hardware.
@@ -322,7 +322,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	// Storage: AutomationTime AccountTasks (r:2 w:1)
 	/// The range of component `v` is `[1, 100]`.
-	fn migration_v5(v: u32, ) -> Weight {
+	fn migration_add_schedule_to_task(v: u32, ) -> Weight {
 		(0 as Weight)
 			// Standard Error: 10_000
 			.saturating_add((8_680_000 as Weight).saturating_mul(v as Weight))
@@ -545,7 +545,7 @@ impl WeightInfo for () {
 	}
 	// Storage: AutomationTime AccountTasks (r:2 w:1)
 	/// The range of component `v` is `[1, 100]`.
-	fn migration_v5(v: u32, ) -> Weight {
+	fn migration_add_schedule_to_task(v: u32, ) -> Weight {
 		(0 as Weight)
 			// Standard Error: 10_000
 			.saturating_add((8_680_000 as Weight).saturating_mul(v as Weight))

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -134,6 +134,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	pallet_automation_time::migrations::v5::MigrateToV5<Runtime>,
 >;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -134,7 +134,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	pallet_automation_time::migrations::v5::MigrateToV5<Runtime>,
+	pallet_automation_time::migrations::add_schedule_to_task::AddScheduleToTask<Runtime>,
 >;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know


### PR DESCRIPTION
This pr adds the `Schedule` enum to `Tasks` to formalize the implicit scheduling variants.
Currently these are either `Fixed` or `Recurring`.
A follow up to this PR will add `Schedule` as an argument to the dynamic dispatch (and maybe xcmp) scheduling extrinsics.