### PR TITLE
Neumann native token id

### DIFF
--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -160,7 +160,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	state_version: 0,
 };
 
-pub const NATIVE_TOKEN_ID: TokenId = 0;
+// TODO: Update to `0` once asset_registry genesis is available.
+pub const NATIVE_TOKEN_ID: TokenId = 1;
 
 /// This determines the average expected block time that we are targeting.
 /// Blocks will be produced at a minimum duration defined by `SLOT_DURATION`.


### PR DESCRIPTION
- set neumann NATIVE_TOKEN_ID to `1` until asset_registry genesis is available
- Native asset must be added first and in the polkadot.js UI

```
decimals: 10,
name: "Native",
symbol: "NEU",
existential_deposit: 0,
location:  MultiLocation::new(0, Here).into()),
additional: CustomMetadata { 
	fee_per_second: 419_000_000_000,
	conversion_rate: None,
}