### PR TITLE
Fix compiler warnings

### DIFF
--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -387,12 +387,10 @@ pub mod pallet {
 			para_id: ParachainId,
 			target_instructions: xcm::v2::Xcm<()>,
 		) -> Result<(), DispatchError> {
-			let destination_location: Junctions =
-				if cfg!(feature = "runtime-benchmarks") && cfg!(not(test)) {
-					Here
-				} else {
-					X1(Junction::Parachain(para_id.into()))
-				};
+			let destination_location = Junction::Parachain(para_id.into());
+
+			#[cfg(all(not(test), feature = "runtime-benchmarks"))]
+			let destination_location: Junctions = Here;
 
 			// Send to target chain
 			T::XcmSender::send_xcm((1, destination_location), target_instructions).map_err(

--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -387,10 +387,12 @@ pub mod pallet {
 			para_id: ParachainId,
 			target_instructions: xcm::v2::Xcm<()>,
 		) -> Result<(), DispatchError> {
-			let destination_location = Junction::Parachain(para_id.into());
-
-			#[cfg(all(not(test), feature = "runtime-benchmarks"))]
-			let destination_location: Junctions = Here;
+			let destination_location: Junctions =
+				if cfg!(feature = "runtime-benchmarks") && cfg!(not(test)) {
+					Here
+				} else {
+					X1(Junction::Parachain(para_id.into()))
+				};
 
 			// Send to target chain
 			T::XcmSender::send_xcm((1, destination_location), target_instructions).map_err(

--- a/pallets/xcmp-handler/src/mock.rs
+++ b/pallets/xcmp-handler/src/mock.rs
@@ -16,7 +16,6 @@
 // limitations under the License.
 
 use crate as pallet_xcmp_handler;
-use codec::{Decode, Encode, MaxEncodedLen};
 use core::cell::RefCell;
 use frame_support::{
 	parameter_types,
@@ -26,13 +25,11 @@ use frame_support::{
 use frame_system as system;
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
-use scale_info::TypeInfo;
-use serde::{Deserialize, Serialize};
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, Convert, IdentityLookup},
-	AccountId32, RuntimeDebug,
+	AccountId32,
 };
 use xcm::latest::prelude::*;
 use xcm_builder::{


### PR DESCRIPTION
Compiler warnings for unused imports make it difficult to recognize when a new issue is introduced.