### PR TITLE
Remove generic param from Schedule enum

### DIFF
--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -85,12 +85,7 @@ pub mod pallet {
 	pub type TaskId<T> = <T as frame_system::Config>::Hash;
 	pub type AccountTaskId<T> = (AccountOf<T>, TaskId<T>);
 	pub type ActionOf<T> = Action<AccountOf<T>, BalanceOf<T>, <T as Config>::CurrencyId>;
-	pub type TaskOf<T> = Task<
-		AccountOf<T>,
-		BalanceOf<T>,
-		<T as Config>::CurrencyId,
-		<T as Config>::MaxExecutionTimes,
-	>;
+	pub type TaskOf<T> = Task<AccountOf<T>, BalanceOf<T>, <T as Config>::CurrencyId>;
 	pub type MissedTaskV2Of<T> = MissedTaskV2<AccountOf<T>, TaskId<T>>;
 	pub type ScheduledTasksOf<T> = ScheduledTasks<AccountOf<T>, TaskId<T>>;
 
@@ -370,8 +365,7 @@ pub mod pallet {
 				Err(Error::<T>::EmptyMessage)?
 			}
 
-			let schedule =
-				Schedule::<T::MaxExecutionTimes>::new_fixed_schedule::<T>(execution_times)?;
+			let schedule = Schedule::new_fixed_schedule::<T>(execution_times)?;
 			Self::validate_and_schedule_task(
 				Action::Notify { message },
 				who,
@@ -424,8 +418,7 @@ pub mod pallet {
 			}
 			let action =
 				Action::NativeTransfer { sender: who.clone(), recipient: recipient_id, amount };
-			let schedule =
-				Schedule::<T::MaxExecutionTimes>::new_fixed_schedule::<T>(execution_times)?;
+			let schedule = Schedule::new_fixed_schedule::<T>(execution_times)?;
 			Self::validate_and_schedule_task(action, who, provided_id, schedule)?;
 			Ok(().into())
 		}
@@ -464,8 +457,7 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			let action = Action::XCMP { para_id, currency_id, encoded_call, encoded_call_weight };
-			let schedule =
-				Schedule::<T::MaxExecutionTimes>::new_fixed_schedule::<T>(execution_times)?;
+			let schedule = Schedule::new_fixed_schedule::<T>(execution_times)?;
 
 			Self::validate_and_schedule_task(action, who, provided_id, schedule)?;
 			Ok(().into())
@@ -504,10 +496,7 @@ pub mod pallet {
 				collator: collator_id,
 				account_minimum,
 			};
-			let schedule = Schedule::<T::MaxExecutionTimes>::new_recurring_schedule::<T>(
-				execution_time,
-				frequency,
-			)?;
+			let schedule = Schedule::new_recurring_schedule::<T>(execution_time, frequency)?;
 			Self::validate_and_schedule_task(action, who, provided_id, schedule)?;
 			Ok(().into())
 		}
@@ -537,8 +526,7 @@ pub mod pallet {
 
 			let encoded_call = call.encode();
 			let action = Action::DynamicDispatch { encoded_call };
-			let schedule =
-				Schedule::<T::MaxExecutionTimes>::new_fixed_schedule::<T>(execution_times)?;
+			let schedule = Schedule::new_fixed_schedule::<T>(execution_times)?;
 
 			Self::validate_and_schedule_task(action, who, provided_id, schedule)?;
 			Ok(().into())
@@ -1284,7 +1272,7 @@ pub mod pallet {
 			action: ActionOf<T>,
 			owner_id: AccountOf<T>,
 			provided_id: Vec<u8>,
-			schedule: Schedule<T::MaxExecutionTimes>,
+			schedule: Schedule,
 		) -> DispatchResult {
 			if provided_id.len() == 0 {
 				Err(Error::<T>::EmptyProvidedId)?

--- a/pallets/automation-time/src/migrations/add_schedule_to_task.rs
+++ b/pallets/automation-time/src/migrations/add_schedule_to_task.rs
@@ -28,7 +28,7 @@ impl<T: Config> From<OldTask<T>> for TaskOf<T> {
 				frequency,
 			},
 			_ => Schedule::Fixed {
-				execution_times: task.execution_times,
+				execution_times: task.execution_times.to_vec(),
 				executions_left: task.executions_left,
 			},
 		};

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -351,8 +351,7 @@ pub fn add_task_to_task_queue(
 	scheduled_times: Vec<u64>,
 	action: ActionOf<Test>,
 ) -> sp_core::H256 {
-	let schedule =
-		Schedule::<MaxExecutionTimes>::new_fixed_schedule::<Test>(scheduled_times).unwrap();
+	let schedule = Schedule::new_fixed_schedule::<Test>(scheduled_times).unwrap();
 	add_to_task_queue(owner, provided_id, schedule, action)
 }
 
@@ -363,16 +362,14 @@ pub fn add_recurring_task_to_task_queue(
 	frequency: u64,
 	action: ActionOf<Test>,
 ) -> sp_core::H256 {
-	let schedule =
-		Schedule::<MaxExecutionTimes>::new_recurring_schedule::<Test>(scheduled_time, frequency)
-			.unwrap();
+	let schedule = Schedule::new_recurring_schedule::<Test>(scheduled_time, frequency).unwrap();
 	add_to_task_queue(owner, provided_id, schedule, action)
 }
 
 pub fn add_to_task_queue(
 	owner: [u8; 32],
 	provided_id: Vec<u8>,
-	schedule: Schedule<MaxExecutionTimes>,
+	schedule: Schedule,
 	action: ActionOf<Test>,
 ) -> sp_core::H256 {
 	let task_id = create_task(owner, provided_id, schedule, action);
@@ -388,8 +385,7 @@ pub fn add_task_to_missed_queue(
 	scheduled_times: Vec<u64>,
 	action: ActionOf<Test>,
 ) -> sp_core::H256 {
-	let schedule =
-		Schedule::<MaxExecutionTimes>::new_fixed_schedule::<Test>(scheduled_times.clone()).unwrap();
+	let schedule = Schedule::new_fixed_schedule::<Test>(scheduled_times.clone()).unwrap();
 	let task_id = create_task(owner, provided_id, schedule, action);
 	let missed_task =
 		MissedTaskV2Of::<Test>::new(AccountId32::new(owner), task_id, scheduled_times[0]);
@@ -402,7 +398,7 @@ pub fn add_task_to_missed_queue(
 pub fn create_task(
 	owner: [u8; 32],
 	provided_id: Vec<u8>,
-	schedule: Schedule<MaxExecutionTimes>,
+	schedule: Schedule,
 	action: ActionOf<Test>,
 ) -> sp_core::H256 {
 	let task_hash_input = TaskHashInput::new(AccountId32::new(owner), provided_id.clone());

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -115,7 +115,7 @@ impl Schedule {
 		mut execution_times: Vec<UnixTime>,
 	) -> Result<Self, DispatchError> {
 		Pallet::<T>::clean_execution_times_vector(&mut execution_times);
-		let executions_left = execution_times.len();
+		let executions_left = execution_times.len() as u32;
 		let schedule = Self::Fixed { execution_times, executions_left };
 		schedule.valid::<T>()?;
 		Ok(schedule)
@@ -248,7 +248,7 @@ impl<AccountId: Clone, Balance, CurrencyId> Task<AccountId, Balance, CurrencyId>
 
 	pub fn execution_times(&self) -> Vec<UnixTime> {
 		match &self.schedule {
-			Schedule::Fixed { execution_times, .. } => execution_times,
+			Schedule::Fixed { execution_times, .. } => execution_times.to_vec(),
 			Schedule::Recurring { next_execution_time, .. } => {
 				vec![*next_execution_time]
 			},

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -397,40 +397,6 @@ mod tests {
 		use frame_support::{assert_err, assert_ok};
 
 		#[test]
-		fn partial_eq() {
-			new_test_ext(0).execute_with(|| {
-				assert_eq!(
-					Schedule::Fixed { execution_times: vec![0], executions_left: 1 },
-					Schedule::Fixed { execution_times: vec![0], executions_left: 1 }
-				);
-				assert_ne!(
-					Schedule::Fixed { execution_times: vec![1], executions_left: 1 },
-					Schedule::Fixed { execution_times: vec![0], executions_left: 1 }
-				);
-				assert_ne!(
-					Schedule::Fixed { execution_times: vec![0, 1], executions_left: 1 },
-					Schedule::Fixed { execution_times: vec![0, 1], executions_left: 2 }
-				);
-				assert_eq!(
-					Schedule::Recurring { next_execution_time: 0, frequency: 3600 },
-					Schedule::Recurring { next_execution_time: 0, frequency: 3600 }
-				);
-				assert_ne!(
-					Schedule::Recurring { next_execution_time: 1, frequency: 3600 },
-					Schedule::Recurring { next_execution_time: 0, frequency: 3600 }
-				);
-				assert_ne!(
-					Schedule::Recurring { next_execution_time: 0, frequency: 7200 },
-					Schedule::Recurring { next_execution_time: 0, frequency: 3600 }
-				);
-				assert_ne!(
-					Schedule::Fixed { execution_times: vec![0], executions_left: 1 },
-					Schedule::Recurring { next_execution_time: 0, frequency: 3600 }
-				);
-			})
-		}
-
-		#[test]
 		fn new_fixed_schedule_sets_executions_left() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
 				let t1 = SCHEDULED_TIME + 3600;

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -88,13 +88,13 @@ impl<AccountId: Clone + Decode, Balance: AtLeast32BitUnsigned, CurrencyId: Defau
 }
 
 #[derive(Debug, Encode, Decode, TypeInfo)]
-#[scale_info(skip_type_params(MaxExecutionTimes))]
-pub enum Schedule<MaxExecutionTimes: Get<u32>> {
-	Fixed { execution_times: BoundedVec<UnixTime, MaxExecutionTimes>, executions_left: u32 },
+pub enum Schedule {
+	Fixed { execution_times: Vec<UnixTime>, executions_left: u32 },
 	Recurring { next_execution_time: UnixTime, frequency: Seconds },
 }
 
-impl<B: Get<u32>> PartialEq for Schedule<B> {
+// TODO: Can PartialEq be derived now?
+impl PartialEq for Schedule {
 	fn eq(&self, other: &Self) -> bool {
 		match (self, other) {
 			(
@@ -110,14 +110,12 @@ impl<B: Get<u32>> PartialEq for Schedule<B> {
 	}
 }
 
-impl<MaxExecutionTimes: Get<u32>> Schedule<MaxExecutionTimes> {
+impl Schedule {
 	pub fn new_fixed_schedule<T: Config>(
 		mut execution_times: Vec<UnixTime>,
 	) -> Result<Self, DispatchError> {
 		Pallet::<T>::clean_execution_times_vector(&mut execution_times);
-		let executions_left = execution_times.len() as u32;
-		let execution_times: BoundedVec<UnixTime, MaxExecutionTimes> =
-			execution_times.try_into().map_err(|_| Error::<T>::TooManyExecutionsTimes)?;
+		let executions_left = execution_times.len();
 		let schedule = Self::Fixed { execution_times, executions_left };
 		schedule.valid::<T>()?;
 		Ok(schedule)
@@ -163,15 +161,15 @@ impl<MaxExecutionTimes: Get<u32>> Schedule<MaxExecutionTimes> {
 /// The struct that stores all information needed for a task.
 #[derive(Debug, Encode, Decode, TypeInfo)]
 #[scale_info(skip_type_params(MaxExecutionTimes))]
-pub struct Task<AccountId, Balance, CurrencyId, MaxExecutionTimes: Get<u32>> {
+pub struct Task<AccountId, Balance, CurrencyId> {
 	pub owner_id: AccountId,
 	pub provided_id: Vec<u8>,
-	pub schedule: Schedule<MaxExecutionTimes>,
+	pub schedule: Schedule,
 	pub action: Action<AccountId, Balance, CurrencyId>,
 }
 
-impl<AccountId: Ord, Balance: Ord, CurrencyId: Ord, MaxExecutionTimes: Get<u32>> PartialEq
-	for Task<AccountId, Balance, CurrencyId, MaxExecutionTimes>
+impl<AccountId: Ord, Balance: Ord, CurrencyId: Ord> PartialEq
+	for Task<AccountId, Balance, CurrencyId>
 {
 	fn eq(&self, other: &Self) -> bool {
 		self.owner_id == other.owner_id &&
@@ -181,18 +179,13 @@ impl<AccountId: Ord, Balance: Ord, CurrencyId: Ord, MaxExecutionTimes: Get<u32>>
 	}
 }
 
-impl<AccountId: Ord, Balance: Ord, CurrencyId: Ord, MaxExecutionTimes: Get<u32>> Eq
-	for Task<AccountId, Balance, CurrencyId, MaxExecutionTimes>
-{
-}
+impl<AccountId: Ord, Balance: Ord, CurrencyId: Ord> Eq for Task<AccountId, Balance, CurrencyId> {}
 
-impl<AccountId: Clone, Balance, CurrencyId, MaxExecutionTimes: Get<u32>>
-	Task<AccountId, Balance, CurrencyId, MaxExecutionTimes>
-{
+impl<AccountId: Clone, Balance, CurrencyId> Task<AccountId, Balance, CurrencyId> {
 	pub fn new(
 		owner_id: AccountId,
 		provided_id: Vec<u8>,
-		schedule: Schedule<MaxExecutionTimes>,
+		schedule: Schedule,
 		action: Action<AccountId, Balance, CurrencyId>,
 	) -> Self {
 		Self { owner_id, provided_id, schedule, action }
@@ -205,7 +198,7 @@ impl<AccountId: Clone, Balance, CurrencyId, MaxExecutionTimes: Get<u32>>
 		message: Vec<u8>,
 	) -> Result<Self, DispatchError> {
 		let action = Action::Notify { message };
-		let schedule = Schedule::<MaxExecutionTimes>::new_fixed_schedule::<T>(execution_times)?;
+		let schedule = Schedule::new_fixed_schedule::<T>(execution_times)?;
 		Ok(Self::new(owner_id, provided_id, schedule, action))
 	}
 
@@ -218,7 +211,7 @@ impl<AccountId: Clone, Balance, CurrencyId, MaxExecutionTimes: Get<u32>>
 	) -> Result<Self, DispatchError> {
 		let action =
 			Action::NativeTransfer { sender: owner_id.clone(), recipient: recipient_id, amount };
-		let schedule = Schedule::<MaxExecutionTimes>::new_fixed_schedule::<T>(execution_times)?;
+		let schedule = Schedule::new_fixed_schedule::<T>(execution_times)?;
 		Ok(Self::new(owner_id, provided_id, schedule, action))
 	}
 
@@ -232,7 +225,7 @@ impl<AccountId: Clone, Balance, CurrencyId, MaxExecutionTimes: Get<u32>>
 		encoded_call_weight: Weight,
 	) -> Result<Self, DispatchError> {
 		let action = Action::XCMP { para_id, currency_id, encoded_call, encoded_call_weight };
-		let schedule = Schedule::<MaxExecutionTimes>::new_fixed_schedule::<T>(execution_times)?;
+		let schedule = Schedule::new_fixed_schedule::<T>(execution_times)?;
 		Ok(Self::new(owner_id, provided_id, schedule, action))
 	}
 
@@ -249,16 +242,13 @@ impl<AccountId: Clone, Balance, CurrencyId, MaxExecutionTimes: Get<u32>>
 			collator: collator_id,
 			account_minimum,
 		};
-		let schedule = Schedule::<MaxExecutionTimes>::new_recurring_schedule::<T>(
-			next_execution_time,
-			frequency,
-		)?;
+		let schedule = Schedule::new_recurring_schedule::<T>(next_execution_time, frequency)?;
 		Ok(Self::new(owner_id, provided_id, schedule, action))
 	}
 
 	pub fn execution_times(&self) -> Vec<UnixTime> {
 		match &self.schedule {
-			Schedule::Fixed { execution_times, .. } => execution_times.to_vec(),
+			Schedule::Fixed { execution_times, .. } => execution_times,
 			Schedule::Recurring { next_execution_time, .. } => {
 				vec![*next_execution_time]
 			},
@@ -306,7 +296,7 @@ impl<AccountId, TaskId> ScheduledTasks<AccountId, TaskId> {
 	pub fn try_push<T: Config, Balance>(
 		&mut self,
 		task_id: TaskId,
-		task: &Task<AccountId, Balance, T::CurrencyId, T::MaxExecutionTimes>,
+		task: &Task<AccountId, Balance, T::CurrencyId>,
 	) -> Result<&mut Self, DispatchError>
 	where
 		AccountId: Clone,
@@ -419,71 +409,32 @@ mod tests {
 		fn partial_eq() {
 			new_test_ext(0).execute_with(|| {
 				assert_eq!(
-					Schedule::<MaxExecutionTimes>::Fixed {
-						execution_times: vec![0].try_into().unwrap(),
-						executions_left: 1
-					},
-					Schedule::<MaxExecutionTimes>::Fixed {
-						execution_times: vec![0].try_into().unwrap(),
-						executions_left: 1
-					}
+					Schedule::Fixed { execution_times: vec![0], executions_left: 1 },
+					Schedule::Fixed { execution_times: vec![0], executions_left: 1 }
 				);
 				assert_ne!(
-					Schedule::<MaxExecutionTimes>::Fixed {
-						execution_times: vec![1].try_into().unwrap(),
-						executions_left: 1
-					},
-					Schedule::<MaxExecutionTimes>::Fixed {
-						execution_times: vec![0].try_into().unwrap(),
-						executions_left: 1
-					}
+					Schedule::Fixed { execution_times: vec![1], executions_left: 1 },
+					Schedule::Fixed { execution_times: vec![0], executions_left: 1 }
 				);
 				assert_ne!(
-					Schedule::<MaxExecutionTimes>::Fixed {
-						execution_times: vec![0, 1].try_into().unwrap(),
-						executions_left: 1
-					},
-					Schedule::<MaxExecutionTimes>::Fixed {
-						execution_times: vec![0, 1].try_into().unwrap(),
-						executions_left: 2
-					}
+					Schedule::Fixed { execution_times: vec![0, 1], executions_left: 1 },
+					Schedule::Fixed { execution_times: vec![0, 1], executions_left: 2 }
 				);
 				assert_eq!(
-					Schedule::<MaxExecutionTimes>::Recurring {
-						next_execution_time: 0,
-						frequency: 3600
-					},
+					Schedule::Recurring { next_execution_time: 0, frequency: 3600 },
 					Schedule::Recurring { next_execution_time: 0, frequency: 3600 }
 				);
 				assert_ne!(
-					Schedule::<MaxExecutionTimes>::Recurring {
-						next_execution_time: 1,
-						frequency: 3600
-					},
-					Schedule::<MaxExecutionTimes>::Recurring {
-						next_execution_time: 0,
-						frequency: 3600
-					}
+					Schedule::Recurring { next_execution_time: 1, frequency: 3600 },
+					Schedule::Recurring { next_execution_time: 0, frequency: 3600 }
 				);
 				assert_ne!(
-					Schedule::<MaxExecutionTimes>::Recurring {
-						next_execution_time: 0,
-						frequency: 7200
-					},
-					Schedule::<MaxExecutionTimes>::Recurring {
-						next_execution_time: 0,
-						frequency: 3600
-					}
+					Schedule::Recurring { next_execution_time: 0, frequency: 7200 },
+					Schedule::Recurring { next_execution_time: 0, frequency: 3600 }
 				);
 				assert_ne!(
-					Schedule::<MaxExecutionTimes>::Fixed {
-						execution_times: vec![0].try_into().unwrap(),
-						executions_left: 1
-					},
-					Schedule::<MaxExecutionTimes>::Recurring {
-						next_execution_time: 0,
-						frequency: 3600
-					}
+					Schedule::Fixed { execution_times: vec![0], executions_left: 1 },
+					Schedule::Recurring { next_execution_time: 0, frequency: 3600 }
 				);
 			})
 		}
@@ -494,8 +445,7 @@ mod tests {
 				let t1 = SCHEDULED_TIME + 3600;
 				let t2 = SCHEDULED_TIME + 3600 * 2;
 				let t3 = SCHEDULED_TIME + 3600 * 3;
-				let s = Schedule::<MaxExecutionTimes>::new_fixed_schedule::<Test>(vec![t1, t2, t3])
-					.unwrap();
+				let s = Schedule::new_fixed_schedule::<Test>(vec![t1, t2, t3]).unwrap();
 				if let Schedule::Fixed { executions_left, .. } = s {
 					assert_eq!(executions_left, 3);
 				} else {
@@ -507,7 +457,7 @@ mod tests {
 		#[test]
 		fn new_fixed_schedule_errors_with_too_many_executions() {
 			new_test_ext(0).execute_with(|| {
-				let s = Schedule::<MaxExecutionTimes>::new_fixed_schedule::<Test>(
+				let s = Schedule::new_fixed_schedule::<Test>(
 					(0u64..=MaxExecutionTimes::get() as u64).collect(),
 				);
 				assert_err!(s, Error::<Test>::TooManyExecutionsTimes);
@@ -520,9 +470,7 @@ mod tests {
 				let t1 = SCHEDULED_TIME + 3600;
 				let t2 = SCHEDULED_TIME + 3600 * 2;
 				let t3 = SCHEDULED_TIME + 3600 * 3;
-				let s = Schedule::<MaxExecutionTimes>::new_fixed_schedule::<Test>(vec![
-					t1, t3, t2, t3, t3,
-				]);
+				let s = Schedule::new_fixed_schedule::<Test>(vec![t1, t3, t2, t3, t3]);
 				if let Schedule::Fixed { execution_times, .. } = s.unwrap() {
 					assert_eq!(execution_times, vec![t1, t2, t3]);
 				} else {
@@ -534,11 +482,9 @@ mod tests {
 		#[test]
 		fn checks_for_fixed_schedule_validity() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				assert_ok!(Schedule::<MaxExecutionTimes>::new_fixed_schedule::<Test>(vec![
-					SCHEDULED_TIME + 3600
-				]));
+				assert_ok!(Schedule::new_fixed_schedule::<Test>(vec![SCHEDULED_TIME + 3600]));
 				assert_err!(
-					Schedule::<MaxExecutionTimes>::new_fixed_schedule::<Test>(vec![
+					Schedule::new_fixed_schedule::<Test>(vec![
 						SCHEDULED_TIME + 3600,
 						SCHEDULED_TIME + 3650
 					]),
@@ -551,41 +497,32 @@ mod tests {
 		fn checks_for_recurring_schedule_validity() {
 			let start_time = 1_663_225_200;
 			new_test_ext(start_time * 1_000).execute_with(|| {
-				assert_ok!(Schedule::<MaxExecutionTimes>::Recurring {
+				assert_ok!(Schedule::Recurring {
 					next_execution_time: start_time + 3600,
 					frequency: 3600
 				}
 				.valid::<Test>());
 				// Next execution time not at hour granuality
 				assert_err!(
-					Schedule::<MaxExecutionTimes>::Recurring {
-						next_execution_time: start_time + 3650,
-						frequency: 3600
-					}
-					.valid::<Test>(),
+					Schedule::Recurring { next_execution_time: start_time + 3650, frequency: 3600 }
+						.valid::<Test>(),
 					Error::<Test>::InvalidTime
 				);
 				// Frequency not at hour granularity
 				assert_err!(
-					Schedule::<MaxExecutionTimes>::Recurring {
-						next_execution_time: start_time + 3650,
-						frequency: 3650
-					}
-					.valid::<Test>(),
+					Schedule::Recurring { next_execution_time: start_time + 3650, frequency: 3650 }
+						.valid::<Test>(),
 					Error::<Test>::InvalidTime
 				);
 				// Frequency of 0
 				assert_err!(
-					Schedule::<MaxExecutionTimes>::Recurring {
-						next_execution_time: start_time + 3600,
-						frequency: 0
-					}
-					.valid::<Test>(),
+					Schedule::Recurring { next_execution_time: start_time + 3600, frequency: 0 }
+						.valid::<Test>(),
 					Error::<Test>::InvalidTime
 				);
 				// Frequency too far out
 				assert_err!(
-					Schedule::<MaxExecutionTimes>::Recurring {
+					Schedule::Recurring {
 						next_execution_time: start_time + 3600,
 						frequency: start_time + 3600
 					}
@@ -598,7 +535,7 @@ mod tests {
 		#[test]
 		fn number_of_known_executions_for_fixed() {
 			new_test_ext(0).execute_with(|| {
-				let s = Schedule::<MaxExecutionTimes>::Fixed {
+				let s = Schedule::Fixed {
 					execution_times: vec![].try_into().unwrap(),
 					executions_left: 5,
 				};
@@ -609,10 +546,7 @@ mod tests {
 		#[test]
 		fn number_of_known_executions_for_recurring() {
 			new_test_ext(0).execute_with(|| {
-				let s = Schedule::<MaxExecutionTimes>::Recurring {
-					next_execution_time: 0,
-					frequency: 0,
-				};
+				let s = Schedule::Recurring { next_execution_time: 0, frequency: 0 };
 				assert_eq!(s.number_of_known_executions(), 1);
 			})
 		}

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -87,27 +87,10 @@ impl<AccountId: Clone + Decode, Balance: AtLeast32BitUnsigned, CurrencyId: Defau
 	}
 }
 
-#[derive(Debug, Encode, Decode, TypeInfo)]
+#[derive(Debug, Encode, Decode, PartialEq, TypeInfo)]
 pub enum Schedule {
 	Fixed { execution_times: Vec<UnixTime>, executions_left: u32 },
 	Recurring { next_execution_time: UnixTime, frequency: Seconds },
-}
-
-// TODO: Can PartialEq be derived now?
-impl PartialEq for Schedule {
-	fn eq(&self, other: &Self) -> bool {
-		match (self, other) {
-			(
-				Schedule::Fixed { execution_times: t1, executions_left: l1 },
-				Schedule::Fixed { execution_times: t2, executions_left: l2 },
-			) => t1.to_vec() == t2.to_vec() && l1 == l2,
-			(
-				Schedule::Recurring { next_execution_time: t1, frequency: f1 },
-				Schedule::Recurring { next_execution_time: t2, frequency: f2 },
-			) => t1 == t2 && f1 == f2,
-			_ => false,
-		}
-	}
 }
 
 impl Schedule {


### PR DESCRIPTION
Simplifies the Schedule enum removing the generic `MaxExecutionTimes` arg used for storing execution times as a `BoundedVec`. Instead, in this pr, execution_times are stored as a `Vec` and number of executions is checked for validity in the `valid` method.