### PR TITLE
Schedule is invalid with no execution times

### DIFF
--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -440,11 +440,17 @@ mod tests {
 		fn checks_for_fixed_schedule_validity() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
 				assert_ok!(Schedule::new_fixed_schedule::<Test>(vec![SCHEDULED_TIME + 3600]));
+				// Execution time does not end in whole hour
 				assert_err!(
 					Schedule::new_fixed_schedule::<Test>(vec![
 						SCHEDULED_TIME + 3600,
 						SCHEDULED_TIME + 3650
 					]),
+					Error::<Test>::InvalidTime
+				);
+				// No execution times
+				assert_err!(
+					Schedule::new_fixed_schedule::<Test>(vec![]),
 					Error::<Test>::InvalidTime
 				);
 			})

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -127,6 +127,9 @@ impl Schedule {
 					.len()
 					.checked_into()
 					.ok_or(Error::<T>::TooManyExecutionsTimes)?;
+				if number_of_executions == 0 {
+					Err(Error::<T>::InvalidTime)?;
+				}
 				if number_of_executions > T::MaxExecutionTimes::get() {
 					Err(Error::<T>::TooManyExecutionsTimes)?;
 				}


### PR DESCRIPTION
This bug allowed users to submit tasks with no execution_times that would sit in storage forever.
Tasks are only cleaned from storage once they are executed.