### PR TITLE
Upload binary after build

### DIFF
--- a/.github/workflows/neumann-docker.yml
+++ b/.github/workflows/neumann-docker.yml
@@ -23,6 +23,11 @@ jobs:
           cargo build --locked --release --features neumann-node --features dev-queue
           mkdir -p artifacts/
           cp target/release/oak-collator artifacts/
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: oak-collator
+          path: artifacts/
   build-docker:
     name: Build Docker
     runs-on: ubuntu-latest


### PR DESCRIPTION
Missed this step in the earlier pr. Since this action is kicked off manually, I'm unable to test before merging.