### PR TITLE
Add automation fee details rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5384,6 +5384,8 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
+ "sp-core",
+ "sp-rpc",
  "sp-runtime",
 ]
 

--- a/pallets/automation-time/rpc/Cargo.toml
+++ b/pallets/automation-time/rpc/Cargo.toml
@@ -19,7 +19,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
+sp-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }
 
 pallet-automation-time-rpc-runtime-api = { path = "./runtime-api" }
-
-

--- a/pallets/automation-time/rpc/runtime-api/src/lib.rs
+++ b/pallets/automation-time/rpc/runtime-api/src/lib.rs
@@ -41,6 +41,14 @@ pub enum AutomationAction {
 	AutoCompoundDelegatedStake,
 }
 
+#[derive(Debug, PartialEq, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+pub struct FeeDetails<Balance> {
+	pub execution_fee: Balance,
+	pub xcmp_fee: Balance,
+}
+
 sp_api::decl_runtime_apis! {
 	pub trait AutomationTimeApi<AccountId, Hash, Balance> where
 		AccountId: Codec,
@@ -48,6 +56,7 @@ sp_api::decl_runtime_apis! {
 		Balance: Codec,
 	{
 		fn generate_task_id(account_id: AccountId, provided_id: Vec<u8>) -> Hash;
+		fn query_fee_details(uxt: Block::Extrinsic) -> Result<FeeDetails<Balance>, Vec<u8>>;
 		fn get_time_automation_fees(action: AutomationAction, executions: u32) -> Balance;
 		fn calculate_optimal_autostaking(
 			principal: i128,

--- a/pallets/automation-time/rpc/src/lib.rs
+++ b/pallets/automation-time/rpc/src/lib.rs
@@ -26,6 +26,7 @@ use pallet_automation_time_rpc_runtime_api::{AutomationAction, AutostakingResult
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_core::Bytes;
+use sp_rpc::number::NumberOrHex;
 use sp_runtime::{
 	generic::BlockId,
 	traits::{Block as BlockT, MaybeDisplay},
@@ -49,7 +50,7 @@ pub trait AutomationTimeApi<BlockHash, AccountId, Hash, Balance> {
 		&self,
 		encoded_xt: Bytes,
 		at: Option<BlockHash>,
-	) -> RpcResult<FeeDetails<u64>>;
+	) -> RpcResult<FeeDetails<NumberOrHex>>;
 
 	#[method(name = "automationTime_getTimeAutomationFees")]
 	fn get_time_automation_fees(
@@ -107,7 +108,8 @@ impl<C, Block, AccountId, Hash, Balance>
 	for AutomationTime<C, Block>
 where
 	Block: BlockT,
-	Balance: Codec + MaybeDisplay + Copy + TryInto<u64> + Send + Sync + 'static,
+	Balance:
+		Codec + MaybeDisplay + Copy + TryInto<NumberOrHex> + TryInto<u64> + Send + Sync + 'static,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
 	C::Api: AutomationTimeRuntimeApi<Block, AccountId, Hash, Balance>,
 	AccountId: Codec,
@@ -137,7 +139,7 @@ where
 		&self,
 		encoded_xt: Bytes,
 		at: Option<Block::Hash>,
-	) -> RpcResult<FeeDetails<u64>> {
+	) -> RpcResult<FeeDetails<NumberOrHex>> {
 		let api = self.client.runtime_api();
 		let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
 
@@ -169,7 +171,7 @@ where
 			value.try_into().map_err(|_| {
 				JsonRpseeError::Call(CallError::Custom(ErrorObject::owned(
 					Error::RuntimeError.into(),
-					format!("{} doesn't fit in u64 representation", value),
+					format!("{} doesn't fit in NumberOrHex representation", value),
 					None::<()>,
 				)))
 			})

--- a/pallets/automation-time/rpc/src/lib.rs
+++ b/pallets/automation-time/rpc/src/lib.rs
@@ -15,18 +15,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use codec::Codec;
+use codec::{Codec, Decode};
 use jsonrpsee::{
 	core::{async_trait, Error as JsonRpseeError, RpcResult},
 	proc_macros::rpc,
 	types::error::{CallError, ErrorObject},
 };
 pub use pallet_automation_time_rpc_runtime_api::AutomationTimeApi as AutomationTimeRuntimeApi;
-use pallet_automation_time_rpc_runtime_api::{AutomationAction, AutostakingResult};
+use pallet_automation_time_rpc_runtime_api::{AutomationAction, AutostakingResult, FeeDetails};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
-use sp_runtime::{generic::BlockId, traits::Block as BlockT};
-use std::{fmt::Debug, sync::Arc};
+use sp_core::Bytes;
+use sp_runtime::{
+	generic::BlockId,
+	traits::{Block as BlockT, MaybeDisplay},
+};
+use std::sync::Arc;
 
 /// An RPC endpoint to provide information about tasks.
 #[rpc(client, server)]
@@ -39,6 +43,13 @@ pub trait AutomationTimeApi<BlockHash, AccountId, Hash, Balance> {
 		provided_id: String,
 		at: Option<BlockHash>,
 	) -> RpcResult<Hash>;
+
+	#[method(name = "automationTime_queryFeeDetails")]
+	fn query_fee_details(
+		&self,
+		encoded_xt: Bytes,
+		at: Option<BlockHash>,
+	) -> RpcResult<FeeDetails<u64>>;
 
 	#[method(name = "automationTime_getTimeAutomationFees")]
 	fn get_time_automation_fees(
@@ -96,7 +107,7 @@ impl<C, Block, AccountId, Hash, Balance>
 	for AutomationTime<C, Block>
 where
 	Block: BlockT,
-	Balance: Codec + Copy + TryInto<u64> + Debug,
+	Balance: Codec + MaybeDisplay + Copy + TryInto<u64> + Send + Sync + 'static,
 	C: Send + Sync + 'static + ProvideRuntimeApi<Block> + HeaderBackend<Block>,
 	C::Api: AutomationTimeRuntimeApi<Block, AccountId, Hash, Balance>,
 	AccountId: Codec,
@@ -119,6 +130,54 @@ where
 				"Unable to generate task_id",
 				Some(format!("{:?}", e)),
 			)))
+		})
+	}
+
+	fn query_fee_details(
+		&self,
+		encoded_xt: Bytes,
+		at: Option<Block::Hash>,
+	) -> RpcResult<FeeDetails<u64>> {
+		let api = self.client.runtime_api();
+		let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));
+
+		let uxt: Block::Extrinsic = Decode::decode(&mut &*encoded_xt).map_err(|e| {
+			CallError::Custom(ErrorObject::owned(
+				Error::RuntimeError.into(),
+				format!("Unable to decode extrinsic."),
+				Some(format!("{:?}", e)),
+			))
+		})?;
+		let fee_details = api
+			.query_fee_details(&at, uxt)
+			.map_err(|e| {
+				CallError::Custom(ErrorObject::owned(
+					Error::RuntimeError.into(),
+					format!("Unable to query fee details."),
+					Some(format!("{:?}", e)),
+				))
+			})?
+			.map_err(|e| {
+				JsonRpseeError::Call(CallError::Custom(ErrorObject::owned(
+					Error::RuntimeError.into(),
+					"Unable to get fees.",
+					Some(String::from_utf8(e).unwrap_or(String::default())),
+				)))
+			})?;
+
+		let try_into_rpc_balance = |value: Balance| {
+			value.try_into().map_err(|_| {
+				JsonRpseeError::Call(CallError::Custom(ErrorObject::owned(
+					Error::RuntimeError.into(),
+					format!("{} doesn't fit in u64 representation", value),
+					None::<()>,
+				)))
+			})
+		};
+
+		Ok(FeeDetails {
+			execution_fee: try_into_rpc_balance(fee_details.execution_fee)?,
+			xcmp_fee: try_into_rpc_balance(fee_details.xcmp_fee)?,
 		})
 	}
 

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -24,7 +24,9 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use hex_literal::hex;
-use pallet_automation_time_rpc_runtime_api::{AutomationAction, AutostakingResult};
+use pallet_automation_time_rpc_runtime_api::{
+	AutomationAction, AutostakingResult, FeeDetails as AutomationFeeDetails,
+};
 use primitives::{assets::CustomMetadata, TokenId};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, Bytes, OpaqueMetadata};
@@ -1139,6 +1141,38 @@ impl_runtime_apis! {
 		fn generate_task_id(account_id: AccountId, provided_id: Vec<u8>) -> Hash {
 			AutomationTime::generate_task_id(account_id, provided_id)
 		}
+
+		fn query_fee_details(
+			uxt: <Block as BlockT>::Extrinsic,
+		) -> Result<AutomationFeeDetails<Balance>, Vec<u8>> {
+			use pallet_automation_time::Action;
+
+			let (action, executions) = match uxt.function {
+				Call::AutomationTime(pallet_automation_time::Call::schedule_xcmp_task{
+					para_id, currency_id, encoded_call, encoded_call_weight, schedule, ..
+				}) => {
+					let action = Action::XCMP { para_id, currency_id, encoded_call, encoded_call_weight };
+					Ok((action, schedule.number_of_executions()))
+				},
+				Call::AutomationTime(pallet_automation_time::Call::schedule_dynamic_dispatch_task{
+					call, schedule, ..
+				}) => {
+					let action = Action::DynamicDispatch { encoded_call: call.encode() };
+					Ok((action, schedule.number_of_executions()))
+				},
+				_ => Err("Unsupported Extrinsic".as_bytes())
+			}?;
+
+			let nobody = AccountId::decode(&mut sp_runtime::traits::TrailingZeroInput::zeroes()).expect("always works");
+			let fee_handler = <Self as pallet_automation_time::Config>::FeeHandler::new(&nobody, &action, executions)
+				.map_err(|_| "Unable to parse fee".as_bytes())?;
+
+			Ok(AutomationFeeDetails {
+				execution_fee: fee_handler.execution_fee.into(),
+				xcmp_fee: fee_handler.xcmp_fee.into()
+			})
+		}
+
 		/**
 		 * The get_time_automation_fees RPC function is used to get the execution fee of scheduling a time-automation task.
 		 * This function requires the action type and the number of executions in order to generate an estimate.

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -24,7 +24,9 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use hex_literal::hex;
-use pallet_automation_time_rpc_runtime_api::{AutomationAction, AutostakingResult};
+use pallet_automation_time_rpc_runtime_api::{
+	AutomationAction, AutostakingResult, FeeDetails as AutomationFeeDetails,
+};
 use primitives::{assets::CustomMetadata, TokenId};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, Bytes, OpaqueMetadata};
@@ -1152,6 +1154,38 @@ impl_runtime_apis! {
 		fn generate_task_id(account_id: AccountId, provided_id: Vec<u8>) -> Hash {
 			AutomationTime::generate_task_id(account_id, provided_id)
 		}
+
+		fn query_fee_details(
+			uxt: <Block as BlockT>::Extrinsic,
+		) -> Result<AutomationFeeDetails<Balance>, Vec<u8>> {
+			use pallet_automation_time::Action;
+
+			let (action, executions) = match uxt.function {
+				Call::AutomationTime(pallet_automation_time::Call::schedule_xcmp_task{
+					para_id, currency_id, encoded_call, encoded_call_weight, schedule, ..
+				}) => {
+					let action = Action::XCMP { para_id, currency_id, encoded_call, encoded_call_weight };
+					Ok((action, schedule.number_of_executions()))
+				},
+				Call::AutomationTime(pallet_automation_time::Call::schedule_dynamic_dispatch_task{
+					call, schedule, ..
+				}) => {
+					let action = Action::DynamicDispatch { encoded_call: call.encode() };
+					Ok((action, schedule.number_of_executions()))
+				},
+				_ => Err("Unsupported Extrinsic".as_bytes())
+			}?;
+
+			let nobody = AccountId::decode(&mut sp_runtime::traits::TrailingZeroInput::zeroes()).expect("always works");
+			let fee_handler = <Self as pallet_automation_time::Config>::FeeHandler::new(&nobody, &action, executions)
+				.map_err(|_| "Unable to parse fee".as_bytes())?;
+
+			Ok(AutomationFeeDetails {
+				execution_fee: fee_handler.execution_fee.into(),
+				xcmp_fee: fee_handler.xcmp_fee.into()
+			})
+		}
+
 		/**
 		 * The get_time_automation_fees RPC function is used to get the execution fee of scheduling a time-automation task.
 		 * This function requires the action type and the number of executions in order to generate an estimate.


### PR DESCRIPTION
Example error
```
❯ curl --location \
  --request POST \
  --header 'Content-Type: application/json' \
  --data-raw '{"id":1, "jsonrpc":"2.0", "method": "automationTime_queryFeeDetails", "params": ["0xe50184001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c01e08c0bd95c44bd883d6c1a0227cfbbf56df2213b8c4214da16320e978bb17e4b98c80e72f2d23b2a1f2db6748a36336c6739df03376ae07808bdcd91060f118b640100003c000c313233040000000000000000086869"]}' \
 'http://localhost:8855'

{"jsonrpc":"2.0","error":{"code":1,"message":"Unable to get fees.","data":"Unsupported Extrinsic"},"id":1}
```

Example success
```
❯ curl --location \
  --request POST \
  --header 'Content-Type: application/json' \
  --data-raw '{"id":1, "jsonrpc":"2.0", "method": "automationTime_queryFeeDetails", "params": ["0x65038400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0144deecb868682c91be4823609da58bd8e33eff79d73625bcfe8c0be6bc9cff6cfa542043380a4c6cea6a4b3caaf3382e16f7b2ef3f20ccc4465363a75a0d908a340000003c026878636d705f6175746f6d6174696f6e5f746573745f3763627338000400000000000000003e08000000000000e83700d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01000d060800000064000000000000000000000000000000c0b81e7200000000"]}' \
 'http://localhost:8855'

{"jsonrpc":"2.0","result":{"executionFee":"0x1ae957e00","xcmpFee":"0x3a5f19800"},"id":1}
```
Fees are hex for serialization of u128 with serde. `0x1ae957e00` -> `7224000000`, `0x3a5f19800` -> `15668975616`