### PR TITLE
Remove xcmp-handler fees rpc

### DIFF
--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -19,6 +19,7 @@ pub mod oak;
 #[cfg(feature = "turing-node")]
 pub mod turing;
 
+#[allow(dead_code)]
 pub const TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 pub type DummyChainSpec = sc_service::GenericChainSpec<(), Extensions>;
 
@@ -122,6 +123,7 @@ pub mod test {
 	/// Validate that the allocated fits the following criteria:
 	/// - no duplicate accounts
 	/// - total allocated is equal to total_tokens
+	#[allow(dead_code)]
 	pub fn validate_allocation(
 		allocated_accounts: Vec<(AccountId, Balance)>,
 		total_tokens: u128,
@@ -152,6 +154,7 @@ pub mod test {
 
 	/// Validate that the vested fits the following criteria:
 	/// - allocated and vesting tokens add up to equal total number of expected tokens
+	#[allow(dead_code)]
 	pub fn validate_total_tokens(
 		allocated_accounts: Vec<(AccountId, Balance)>,
 		vesting_timeslots: Vec<(u64, Vec<(AccountId, Balance)>)>,
@@ -182,6 +185,7 @@ pub mod test {
 	/// - no duplicate accountIds per timestamp
 	/// - total amount vested is correct
 	/// - times are within a given range
+	#[allow(dead_code)]
 	pub fn validate_vesting(
 		vesting_timeslots: Vec<(u64, Vec<(AccountId, Balance)>)>,
 		total_tokens: u128,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -25,7 +25,7 @@ use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface};
 use sc_client_api::ExecutorProvider;
 use sc_executor::NativeElseWasmExecutor;
 use sc_network::{NetworkBlock, NetworkService};
-use sc_service::{Configuration, PartialComponents, Role, TFullBackend, TFullClient, TaskManager};
+use sc_service::{Configuration, PartialComponents, TFullBackend, TFullClient, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle};
 use sp_api::ConstructRuntimeApi;
 use sp_consensus_aura::sr25519::{AuthorityId as AuraId, AuthorityPair as AuraPair};

--- a/pallets/xcmp-handler/rpc/runtime-api/src/lib.rs
+++ b/pallets/xcmp-handler/rpc/runtime-api/src/lib.rs
@@ -18,7 +18,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::Codec;
-use sp_core::Bytes;
 use sp_runtime::AccountId32;
 use sp_std::vec::Vec;
 
@@ -27,6 +26,5 @@ sp_api::decl_runtime_apis! {
 		Balance: Codec,
 	{
 		fn cross_chain_account(account_id: AccountId32) -> Result<AccountId32, Vec<u8>>;
-		fn fees(encoded_xt: Bytes) -> Result<Balance, Vec<u8>>;
 	}
 }

--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -388,6 +388,7 @@ pub mod pallet {
 			para_id: ParachainId,
 			target_instructions: xcm::v2::Xcm<()>,
 		) -> Result<(), DispatchError> {
+			#[allow(unused_variables)]
 			let destination_location = Junction::Parachain(para_id.into());
 
 			#[cfg(all(not(test), feature = "runtime-benchmarks"))]

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -1091,10 +1091,6 @@ impl_runtime_apis! {
 			Account32Hash::<RelayNetwork, sp_runtime::AccountId32>::convert_ref(multiloc)
 				.map_err(|_| "unable to convert account".into())
 		}
-
-		fn fees(_encoded_xt: Bytes) -> Result<Balance, Vec<u8>> {
-			Ok(10_000_000 as Balance)
-		}
 	}
 
 	impl pallet_automation_time_rpc_runtime_api::AutomationTimeApi<Block, AccountId, Hash, Balance> for Runtime {

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -28,7 +28,7 @@ use pallet_automation_time_rpc_runtime_api::{
 };
 use primitives::{assets::CustomMetadata, TokenId};
 use sp_api::impl_runtime_apis;
-use sp_core::{crypto::KeyTypeId, Bytes, OpaqueMetadata};
+use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto},

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -29,12 +29,12 @@ use pallet_automation_time_rpc_runtime_api::{
 };
 use primitives::{assets::CustomMetadata, TokenId};
 use sp_api::impl_runtime_apis;
-use sp_core::{crypto::KeyTypeId, Bytes, OpaqueMetadata};
+use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	AccountId32, ApplyExtrinsicResult, DispatchError, ModuleError, Percent, RuntimeDebug,
+	AccountId32, ApplyExtrinsicResult, Percent, RuntimeDebug,
 };
 use xcm::{
 	latest::{prelude::*, MultiLocation, NetworkId},

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -1103,38 +1103,6 @@ impl_runtime_apis! {
 			Account32Hash::<RelayNetwork, sp_runtime::AccountId32>::convert_ref(multiloc)
 				.map_err(|_| "unable to convert account".into())
 		}
-
-		fn fees(encoded_xt: Bytes) -> Result<Balance, Vec<u8>> {
-			let extrinsic: <Block as BlockT>::Extrinsic = Decode::decode(&mut &*encoded_xt).unwrap();
-			if let Call::AutomationTime(pallet_automation_time::Call::schedule_xcmp_task{
-				schedule, para_id, currency_id, encoded_call_weight, ..
-			}) = extrinsic.clone().function {
-				let len = encoded_xt.len() as u32;
-
-				let xcm_fee = XcmpHandler::calculate_xcm_fee_and_weight(
-					u32::from(para_id),
-					currency_id,
-					encoded_call_weight,
-				).map_err(|e| {
-					match e {
-						DispatchError::Module(ModuleError{ message: Some(msg), .. }) => msg,
-						_ => "cannot get xcmp fee"
-					}
-				})?.0.saturating_mul(schedule.number_of_executions() as u128);
-				let inclusion_fee = TransactionPayment::query_fee_details(extrinsic, len)
-					.inclusion_fee
-					.ok_or("cannot get inclusion fee")?
-					.base_fee;
-				let execution_fee = AutomationTime::calculate_execution_fee(
-					&(AutomationAction::XCMP.into()),
-					schedule.number_of_executions()
-				).expect("Can only fail for DynamicDispatch and this is always XCMP");
-
-				return Ok(xcm_fee.saturating_add(inclusion_fee).saturating_add(execution_fee))
-			}
-
-			Err("unsupported extrinsic".into())
-		}
 	}
 
 	impl pallet_automation_time_rpc_runtime_api::AutomationTimeApi<Block, AccountId, Hash, Balance> for Runtime {

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -29,12 +29,12 @@ use pallet_automation_time_rpc_runtime_api::{
 };
 use primitives::{assets::CustomMetadata, TokenId};
 use sp_api::impl_runtime_apis;
-use sp_core::{crypto::KeyTypeId, Bytes, OpaqueMetadata};
+use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	AccountId32, ApplyExtrinsicResult, DispatchError, ModuleError, Percent, RuntimeDebug,
+	AccountId32, ApplyExtrinsicResult, Percent, RuntimeDebug,
 };
 use xcm::{
 	latest::{prelude::*, MultiLocation, NetworkId},

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -1116,38 +1116,6 @@ impl_runtime_apis! {
 			Account32Hash::<RelayNetwork, sp_runtime::AccountId32>::convert_ref(multiloc)
 				.map_err(|_| "unable to convert account".into())
 		}
-
-		fn fees(encoded_xt: Bytes) -> Result<Balance, Vec<u8>> {
-			let extrinsic: <Block as BlockT>::Extrinsic = Decode::decode(&mut &*encoded_xt).unwrap();
-			if let Call::AutomationTime(pallet_automation_time::Call::schedule_xcmp_task{
-				schedule, para_id, currency_id, encoded_call_weight, ..
-			}) = extrinsic.clone().function {
-				let len = encoded_xt.len() as u32;
-
-				let xcm_fee = XcmpHandler::calculate_xcm_fee_and_weight(
-					u32::from(para_id),
-					currency_id,
-					encoded_call_weight,
-				).map_err(|e| {
-					match e {
-						DispatchError::Module(ModuleError{ message: Some(msg), .. }) => msg,
-						_ => "cannot get xcmp fee"
-					}
-				})?.0.saturating_mul(schedule.number_of_executions() as u128);
-				let inclusion_fee = TransactionPayment::query_fee_details(extrinsic, len)
-					.inclusion_fee
-					.ok_or("cannot get inclusion fee")?
-					.base_fee;
-				let execution_fee = AutomationTime::calculate_execution_fee(
-					&(AutomationAction::XCMP.into()),
-					schedule.number_of_executions()
-				).expect("Can only fail for DynamicDispatch and this is always XCMP");
-
-				return Ok(xcm_fee.saturating_add(inclusion_fee).saturating_add(execution_fee))
-			}
-
-			Err("unsupported extrinsic".into())
-		}
 	}
 
 	impl pallet_automation_time_rpc_runtime_api::AutomationTimeApi<Block, AccountId, Hash, Balance> for Runtime {


### PR DESCRIPTION
Deprecated by `AutomationTime#queryFeeDetails`. Removing the endpoint from the node to avoid any confusion by partners on which fee rpc is the source of truth.