### PR TITLE
Build Turing Dev docker image

### DIFF
--- a/.github/workflows/turing-dev-docker.yml
+++ b/.github/workflows/turing-dev-docker.yml
@@ -1,0 +1,56 @@
+name: Publish Turing Development Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag for release
+        required: true
+
+jobs:
+  build-binary:
+    name: Build Binary
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.tag }}
+      - name: Setup Rust
+        run: rustup show
+      - name: Build
+        run: |
+          cargo build --locked --release --features turing-node,oak-node,dev-queue
+          mkdir -p artifacts/
+          cp target/release/oak-collator artifacts/
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: oak-collator
+          path: artifacts/
+  build-docker:
+    name: Build Docker
+    runs-on: ubuntu-latest
+    needs: build-binary
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.tag }}
+      - name: Download binary
+        uses: actions/download-artifact@v2
+        with:
+          name: oak-collator
+      - name: Build
+        run: |
+          tag=${{ github.event.inputs.tag }}
+          docker_tag="${tag:1}"
+          docker build -f ./docker/turing/Dockerfile -t oaknetwork/turing-dev:$docker_tag .
+          docker tag oaknetwork/turing:$docker_tag oaknetwork/turing-dev:latest
+          docker push oaknetwork/turing-dev:$docker_tag
+          docker push oaknetwork/turing-dev:latest

--- a/.github/workflows/turing-dev-docker.yml
+++ b/.github/workflows/turing-dev-docker.yml
@@ -51,6 +51,6 @@ jobs:
           tag=${{ github.event.inputs.tag }}
           docker_tag="${tag:1}"
           docker build -f ./docker/turing/Dockerfile -t oaknetwork/turing-dev:$docker_tag .
-          docker tag oaknetwork/turing:$docker_tag oaknetwork/turing-dev:latest
+          docker tag oaknetwork/turing-dev:$docker_tag oaknetwork/turing-dev:latest
           docker push oaknetwork/turing-dev:$docker_tag
           docker push oaknetwork/turing-dev:latest


### PR DESCRIPTION
1. Add `dev-queue` to compilation params.

2. build oaknetwork/turing-dev and publish.