### PR TITLE
Remove old migrations from runtime executor

### DIFF
--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -137,11 +137,6 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	(
-        pallet_automation_time::migrations::add_schedule_to_task::AddScheduleToTask<Runtime>,
-	    pallet_xcmp_handler::migrations::add_mgx_tur_chain_currency_combo::AddMgxTurChainCurrencyCombo<Runtime>,
-        migrations::register_shiden_asset::AddShidenAsset
-    ),
 >;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know


### PR DESCRIPTION
This is a required step after every release to prevent migrations from being re-run on the next release