### PR TITLE
🔧 lower minCandidateStk

### DIFF
--- a/node/src/chain_spec/neumann.rs
+++ b/node/src/chain_spec/neumann.rs
@@ -12,6 +12,7 @@ use crate::chain_spec::{
 	get_account_id_from_seed, get_collator_keys_from_seed, inflation_config, DummyChainSpec,
 	Extensions,
 };
+use codec::Encode;
 use common_runtime::constants::currency::{DOLLAR, TOKEN_DECIMALS};
 use neumann_runtime::{
 	CouncilConfig, PolkadotXcmConfig, SudoConfig, TechnicalMembershipConfig, ValveConfig,
@@ -19,6 +20,7 @@ use neumann_runtime::{
 };
 use pallet_xcmp_handler::XcmFlow;
 use primitives::{AccountId, AuraId, Balance, TokenId};
+use xcm::VersionedMultiLocation;
 
 static TOKEN_SYMBOL: &str = "NEU";
 const SS_58_FORMAT: u32 = 51;
@@ -100,6 +102,7 @@ pub fn development_config() -> ChainSpec {
 					419_000_000_000,
 					1_000_000_000,
 					XcmFlow::Normal,
+					Option::<VersionedMultiLocation>::encode(&None),
 				)],
 			)
 		},
@@ -314,7 +317,7 @@ fn testnet_genesis(
 	vesting_schedule: Vec<(u64, Vec<(AccountId, Balance)>)>,
 	general_councils: Vec<AccountId>,
 	technical_memberships: Vec<AccountId>,
-	xcmp_handler_data: Vec<(u32, TokenId, bool, u128, u64, XcmFlow)>,
+	xcmp_handler_data: Vec<(u32, TokenId, bool, u128, u64, XcmFlow, Vec<u8>)>,
 ) -> neumann_runtime::GenesisConfig {
 	neumann_runtime::GenesisConfig {
 		system: neumann_runtime::SystemConfig {

--- a/node/src/chain_spec/oak.rs
+++ b/node/src/chain_spec/oak.rs
@@ -12,6 +12,7 @@ use crate::chain_spec::{
 	test::{validate_allocation, validate_vesting},
 	Extensions,
 };
+use codec::Encode;
 use common_runtime::constants::currency::{DOLLAR, EXISTENTIAL_DEPOSIT, TOKEN_DECIMALS};
 use oak_runtime::{
 	CouncilConfig, PolkadotXcmConfig, SudoConfig, TechnicalMembershipConfig, ValveConfig,
@@ -19,6 +20,7 @@ use oak_runtime::{
 };
 use pallet_xcmp_handler::XcmFlow;
 use primitives::{AccountId, AuraId, Balance, TokenId};
+use xcm::VersionedMultiLocation;
 
 const TOKEN_SYMBOL: &str = "OAK";
 const SS_58_FORMAT: u32 = 51;
@@ -94,6 +96,7 @@ pub fn oak_development_config() -> ChainSpec {
 					419_000_000_000,
 					1_000_000_000,
 					XcmFlow::Normal,
+					Option::<VersionedMultiLocation>::encode(&None),
 				)],
 			)
 		},
@@ -352,7 +355,7 @@ fn testnet_genesis(
 	vesting_schedule: Vec<(u64, Vec<(AccountId, Balance)>)>,
 	general_councils: Vec<AccountId>,
 	technical_memberships: Vec<AccountId>,
-	xcmp_handler_data: Vec<(u32, TokenId, bool, u128, u64, XcmFlow)>,
+	xcmp_handler_data: Vec<(u32, TokenId, bool, u128, u64, XcmFlow, Vec<u8>)>,
 ) -> oak_runtime::GenesisConfig {
 	let candidate_stake =
 		std::cmp::max(oak_runtime::MinCollatorStk::get(), oak_runtime::MinCandidateStk::get());

--- a/node/src/chain_spec/turing.rs
+++ b/node/src/chain_spec/turing.rs
@@ -113,6 +113,14 @@ pub fn turing_development_config() -> ChainSpec {
 						1_000_000_000,
 						XcmFlow::Alternate,
 					),
+					(
+						1000,
+						turing_runtime::NATIVE_TOKEN_ID,
+						false,
+						10_000_000_000_000_000_000,
+						1_000_000_000,
+						XcmFlow::Alternate,
+					),
 				],
 				vec![
 					(
@@ -174,6 +182,22 @@ pub fn turing_development_config() -> ChainSpec {
 								location: Some(MultiLocation::new(1, X1(Parachain(2000))).into()),
 								additional: CustomMetadata {
 									fee_per_second: Some(416_000_000_000),
+									conversion_rate: None,
+								},
+							},
+						),
+					),
+					(
+						5,
+						orml_asset_registry::AssetMetadata::<Balance, CustomMetadata>::encode(
+							&orml_asset_registry::AssetMetadata {
+								decimals: 18,
+								name: b"Moonbase".to_vec(),
+								symbol: b"DEV".to_vec(),
+								existential_deposit: 1,
+								location: Some(MultiLocation::new(1, X1(Parachain(1000))).into()),
+								additional: CustomMetadata {
+									fee_per_second: Some(10_000_000_000_000_000_000),
 									conversion_rate: None,
 								},
 							},

--- a/node/src/chain_spec/turing.rs
+++ b/node/src/chain_spec/turing.rs
@@ -19,6 +19,7 @@ use xcm::{
 	latest::prelude::{X1, X2},
 	opaque::latest::{Junctions::Here, MultiLocation},
 	v1::Junction::{PalletInstance, Parachain},
+	VersionedMultiLocation,
 	VersionedMultiLocation::V1,
 };
 
@@ -96,6 +97,7 @@ pub fn turing_development_config() -> ChainSpec {
 						419_000_000_000,
 						1_000_000_000,
 						XcmFlow::Normal,
+						Option::<VersionedMultiLocation>::encode(&None),
 					),
 					(
 						2110,
@@ -104,6 +106,7 @@ pub fn turing_development_config() -> ChainSpec {
 						5_376_000_000_000,
 						1_000_000_000,
 						XcmFlow::Normal,
+						Option::<VersionedMultiLocation>::encode(&None),
 					),
 					(
 						2000,
@@ -112,6 +115,7 @@ pub fn turing_development_config() -> ChainSpec {
 						10_000_000_000_000_000_000,
 						1_000_000_000,
 						XcmFlow::Alternate,
+						Option::<VersionedMultiLocation>::encode(&None),
 					),
 					(
 						1000,
@@ -120,6 +124,9 @@ pub fn turing_development_config() -> ChainSpec {
 						10_000_000_000_000_000_000,
 						1_000_000_000,
 						XcmFlow::Alternate,
+						Option::<VersionedMultiLocation>::encode(&Some(
+							MultiLocation::new(0, X1(PalletInstance(3))).into(),
+						)),
 					),
 				],
 				vec![
@@ -237,7 +244,7 @@ fn testnet_genesis(
 	vesting_schedule: Vec<(u64, Vec<(AccountId, Balance)>)>,
 	general_councils: Vec<AccountId>,
 	technical_memberships: Vec<AccountId>,
-	xcmp_handler_data: Vec<(u32, TokenId, bool, u128, u64, XcmFlow)>,
+	xcmp_handler_data: Vec<(u32, TokenId, bool, u128, u64, XcmFlow, Vec<u8>)>,
 	additional_assets: Vec<(TokenId, Vec<u8>)>,
 ) -> turing_runtime::GenesisConfig {
 	let candidate_stake = std::cmp::max(

--- a/node/src/chain_spec/turing.rs
+++ b/node/src/chain_spec/turing.rs
@@ -16,9 +16,9 @@ use turing_runtime::{
 	VestingConfig, XcmpHandlerConfig,
 };
 use xcm::{
-	latest::prelude::X1,
+	latest::prelude::{X1, X2},
 	opaque::latest::{Junctions::Here, MultiLocation},
-	v1::Junction::Parachain,
+	v1::Junction::{PalletInstance, Parachain},
 	VersionedMultiLocation::V1,
 };
 
@@ -195,7 +195,10 @@ pub fn turing_development_config() -> ChainSpec {
 								name: b"Moonbase".to_vec(),
 								symbol: b"DEV".to_vec(),
 								existential_deposit: 1,
-								location: Some(MultiLocation::new(1, X1(Parachain(1000))).into()),
+								location: Some(
+									MultiLocation::new(1, X2(Parachain(1000), PalletInstance(3)))
+										.into(),
+								),
 								additional: CustomMetadata {
 									fee_per_second: Some(10_000_000_000_000_000_000),
 									conversion_rate: None,

--- a/pallets/xcmp-handler/src/benchmarking.rs
+++ b/pallets/xcmp-handler/src/benchmarking.rs
@@ -28,7 +28,7 @@ benchmarks! {
 		let currency_id = T::GetNativeCurrencyId::get();
 		let para_id: u32 = 1000;
 		let xcm_data =
-			XcmCurrencyData { native: false, fee_per_second: 100, instruction_weight: 1_000, flow: XcmFlow::Normal };
+			XcmCurrencyData { native: false, fee_per_second: 100, instruction_weight: 1_000, flow: XcmFlow::Normal, location: None };
 
 	}: add_chain_currency_data(RawOrigin::Root, para_id, currency_id, xcm_data.clone())
 	verify {
@@ -39,7 +39,7 @@ benchmarks! {
 		let currency_id = T::GetNativeCurrencyId::get();
 		let para_id: u32 = 1000;
 		let xcm_data =
-			XcmCurrencyData { native: false, fee_per_second: 100, instruction_weight: 1_000, flow: XcmFlow::Normal };
+			XcmCurrencyData { native: false, fee_per_second: 100, instruction_weight: 1_000, flow: XcmFlow::Normal, location: None };
 		XcmChainCurrencyData::<T>::insert(para_id, currency_id, xcm_data);
 
 	}: remove_chain_currency_data(RawOrigin::Root, para_id, currency_id)

--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -58,7 +58,7 @@ pub mod pallet {
 	use polkadot_parachain::primitives::Sibling;
 	use sp_runtime::traits::{AccountIdConversion, Convert, SaturatedConversion};
 	use sp_std::prelude::*;
-	use xcm::latest::prelude::*;
+	use xcm::{latest::prelude::*, VersionedMultiLocation};
 	use xcm_executor::traits::{InvertLocation, WeightBounds};
 
 	type ParachainId = u32;
@@ -157,11 +157,13 @@ pub mod pallet {
 		ErrorGettingCallWeight,
 		/// Currency not supported
 		CurrencyNotSupported,
+		/// The version of the `VersionedMultiLocation` value used is not able
+		/// to be interpreted.
+		BadVersion,
 	}
 
 	/// Stores all data needed to send an XCM message for chain/currency pair.
-	#[derive(Clone, Copy, Debug, Encode, Decode, PartialEq, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+	#[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo)]
 	pub struct XcmCurrencyData {
 		/// Is the token native to the chain?
 		pub native: bool,
@@ -170,6 +172,7 @@ pub mod pallet {
 		pub instruction_weight: u64,
 		/// The desired instruction flow for the target chain
 		pub flow: XcmFlow,
+		pub location: Option<VersionedMultiLocation>,
 	}
 
 	/// Stores XCM data for a chain/currency pair.
@@ -234,8 +237,10 @@ pub mod pallet {
 			let xcm_data = XcmChainCurrencyData::<T>::get(para_id, currency_id)
 				.ok_or(Error::<T>::CurrencyChainComboNotFound)?;
 
-			let (_, target_instructions) = Self::xcm_instruction_skeleton(para_id, xcm_data)?;
+			let (_, target_instructions) =
+				Self::xcm_instruction_skeleton(para_id, xcm_data.clone())?;
 			let weight = xcm_data
+				.clone()
 				.instruction_weight
 				.checked_mul(target_instructions.len() as u64)
 				.ok_or(Error::<T>::WeightOverflow)?
@@ -281,21 +286,29 @@ pub mod pallet {
 				.try_into()
 				.map_err(|_| Error::<T>::FailedMultiLocationToJunction)?;
 
+			let location = match xcm_data.location {
+				Some(loc) => loc.clone().try_into().map_err(|()| Error::<T>::BadVersion)?,
+				_ => MultiLocation::new(0, Here),
+			};
+
+			let target_asset =
+				MultiAsset { id: Concrete(location), fun: Fungibility::Fungible(fee) };
+
 			let instructions = match xcm_data.flow {
 				XcmFlow::Normal => Self::get_local_currency_instructions(
 					para_id,
+					target_asset,
 					descend_location,
 					transact_encoded_call,
 					transact_encoded_call_weight,
 					weight,
-					fee,
 				)?,
 				XcmFlow::Alternate => Self::get_alternate_flow_instructions(
+					target_asset,
 					descend_location,
 					transact_encoded_call,
 					transact_encoded_call_weight,
 					weight,
-					fee,
 				)?,
 			};
 
@@ -317,21 +330,15 @@ pub mod pallet {
 		/// 	- DepositAsset
 		pub fn get_local_currency_instructions(
 			para_id: ParachainId,
+			local_asset: MultiAsset,
 			descend_location: Junctions,
 			transact_encoded_call: Vec<u8>,
 			transact_encoded_call_weight: u64,
 			xcm_weight: u64,
-			fee: u128,
 		) -> Result<
 			(xcm::latest::Xcm<<T as pallet::Config>::Call>, xcm::latest::Xcm<()>),
 			DispatchError,
 		> {
-			// XCM for local chain
-			let local_asset = MultiAsset {
-				id: Concrete(MultiLocation::new(0, Here)),
-				fun: Fungibility::Fungible(fee),
-			};
-
 			let local_xcm = Xcm(vec![
 				WithdrawAsset::<<T as pallet::Config>::Call>(local_asset.clone().into()),
 				DepositAsset::<<T as pallet::Config>::Call> {
@@ -384,21 +391,15 @@ pub mod pallet {
 		/// 	- RefundSurplus
 		/// 	- DepositAsset
 		fn get_alternate_flow_instructions(
+			target_asset: MultiAsset,
 			descend_location: Junctions,
 			transact_encoded_call: Vec<u8>,
 			transact_encoded_call_weight: u64,
 			xcm_weight: u64,
-			fee: u128,
 		) -> Result<
 			(xcm::latest::Xcm<<T as pallet::Config>::Call>, xcm::latest::Xcm<()>),
 			DispatchError,
 		> {
-			// Default to native currency of target chain
-			let target_asset = MultiAsset {
-				id: Concrete(MultiLocation::new(0, Here)),
-				fun: Fungibility::Fungible(fee),
-			};
-
 			let target_xcm = Xcm(vec![
 				DescendOrigin::<()>(descend_location.clone()),
 				WithdrawAsset::<()>(target_asset.clone().into()),
@@ -539,21 +540,29 @@ pub mod pallet {
 			.try_into()
 			.map_err(|_| Error::<T>::FailedMultiLocationToJunction)?;
 
+			let location = match xcm_data.location {
+				Some(loc) => loc.clone().try_into().map_err(|()| Error::<T>::BadVersion)?,
+				_ => MultiLocation::new(0, Here),
+			};
+
+			let target_asset =
+				MultiAsset { id: Concrete(location), fun: Fungibility::Fungible(0u128) };
+
 			match xcm_data.flow {
 				XcmFlow::Normal => Self::get_local_currency_instructions(
 					para_id,
+					target_asset,
 					nobody,
 					Default::default(),
 					0u64,
 					0u64,
-					0u128,
 				),
 				XcmFlow::Alternate => Self::get_alternate_flow_instructions(
+					target_asset,
 					nobody,
 					Default::default(),
 					0u64,
 					0u64,
-					0u128,
 				),
 			}
 		}
@@ -561,7 +570,7 @@ pub mod pallet {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub chain_data: Vec<(u32, T::CurrencyId, bool, u128, u64, XcmFlow)>,
+		pub chain_data: Vec<(u32, T::CurrencyId, bool, u128, u64, XcmFlow, Vec<u8>)>,
 	}
 
 	#[cfg(feature = "std")]
@@ -574,9 +583,18 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-			for (para_id, currency_id, native, fee_per_second, instruction_weight, flow) in
-				self.chain_data.iter()
+			for (
+				para_id,
+				currency_id,
+				native,
+				fee_per_second,
+				instruction_weight,
+				flow,
+				location_encoded,
+			) in self.chain_data.iter()
 			{
+				let location = Option::<VersionedMultiLocation>::decode(&mut &location_encoded[..])
+					.expect("Error decoding VersionedMultiLocation");
 				XcmChainCurrencyData::<T>::insert(
 					para_id,
 					currency_id,
@@ -585,6 +603,7 @@ pub mod pallet {
 						fee_per_second: *fee_per_second,
 						instruction_weight: *instruction_weight,
 						flow: *flow,
+						location,
 					},
 				);
 			}
@@ -669,6 +688,7 @@ impl<T: Config> XcmpTransactor<T::AccountId, T::CurrencyId> for Pallet<T> {
 			fee_per_second: 416_000_000_000,
 			instruction_weight: 600_000_000,
 			flow: XcmFlow::Normal,
+			location: None,
 		};
 
 		XcmChainCurrencyData::<T>::insert(para_id, currency_id, xcm_data);

--- a/pallets/xcmp-handler/src/migrations/add_location_to_currency_data.rs
+++ b/pallets/xcmp-handler/src/migrations/add_location_to_currency_data.rs
@@ -1,0 +1,97 @@
+use core::marker::PhantomData;
+
+use codec::{Decode, Encode};
+use frame_support::{
+	traits::{Get, OnRuntimeUpgrade},
+	weights::Weight,
+	Twox64Concat,
+};
+use scale_info::TypeInfo;
+
+use crate::{Config, XcmCurrencyData, XcmFlow};
+
+#[cfg(feature = "std")]
+use serde::{Deserialize, Serialize};
+
+/// Pre-migrations storage struct
+#[derive(Clone, Copy, Debug, Encode, Decode, PartialEq, TypeInfo)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct OldXcmCurrencyData {
+	pub native: bool,
+	pub fee_per_second: u128,
+	pub instruction_weight: u64,
+	pub flow: XcmFlow,
+}
+
+impl From<OldXcmCurrencyData> for XcmCurrencyData {
+	fn from(data: OldXcmCurrencyData) -> Self {
+		XcmCurrencyData {
+			native: data.native,
+			fee_per_second: data.fee_per_second,
+			instruction_weight: data.instruction_weight,
+			flow: data.flow,
+			location: None,
+		}
+	}
+}
+
+#[frame_support::storage_alias]
+pub type XcmChainCurrencyData<T: Config> = StorageDoubleMap<
+	XcmpHandler,
+	Twox64Concat,
+	u32,
+	Twox64Concat,
+	<T as Config>::CurrencyId,
+	OldXcmCurrencyData,
+>;
+
+pub struct AddLocationToCurrencyData<T>(PhantomData<T>);
+impl<T: Config> OnRuntimeUpgrade for AddLocationToCurrencyData<T> {
+	fn on_runtime_upgrade() -> Weight {
+		log::info!(target: "xcmp-handler", "AddLocationToCurrencyData migration");
+
+		let migrated_count = XcmChainCurrencyData::<T>::iter()
+			.map(|(parachain_id, currency_id, xcm_data)| {
+				let migrated_data = XcmCurrencyData::from(xcm_data);
+				crate::XcmChainCurrencyData::<T>::insert(
+					parachain_id,
+					currency_id,
+					migrated_data.clone(),
+				);
+				log::info!(target: "xcmp-handler", "AddLocationToCurrencyData migrated para_id: {}", parachain_id);
+				migrated_data
+			})
+			.count();
+
+		log::info!(target: "xcmp-handler", "AddLocationToCurrencyData successful! Migrated {} object.", migrated_count);
+
+		T::DbWeight::get().reads_writes(migrated_count as u64, migrated_count as u64)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		use frame_support::traits::OnRuntimeUpgradeHelpersExt;
+
+		let count = XcmChainCurrencyData::<T>::iter().count();
+		Self::set_temp_storage::<u32>(count as u32, "pre_migration_xcm_data_count");
+
+		Ok(())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		use frame_support::traits::OnRuntimeUpgradeHelpersExt;
+
+		let post_count = crate::XcmChainCurrencyData::<T>::iter().count() as u32;
+		let pre_count = Self::get_temp_storage::<u32>("pre_migration_xcm_data_count").unwrap();
+
+		assert_eq!(post_count, pre_count);
+
+		log::info!(
+			target: "xcmp-handler",
+			"AddLocationToCurrencyData try-runtime checks complete"
+		);
+
+		Ok(())
+	}
+}

--- a/pallets/xcmp-handler/src/migrations/mod.rs
+++ b/pallets/xcmp-handler/src/migrations/mod.rs
@@ -1,5 +1,6 @@
 // Migrations
 
 // mod old;
+// pub mod add_flow_to_currency_data;
 
-pub mod add_flow_to_currency_data;
+pub mod add_location_to_currency_data;

--- a/pallets/xcmp-handler/src/mock.rs
+++ b/pallets/xcmp-handler/src/mock.rs
@@ -288,7 +288,7 @@ impl pallet_xcmp_handler::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext(
-	genesis_config: Option<Vec<(u32, CurrencyId, bool, u128, u64, XcmFlow)>>,
+	genesis_config: Option<Vec<(u32, CurrencyId, bool, u128, u64, XcmFlow, Vec<u8>)>>,
 ) -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default()
 		.build_storage::<Test>()

--- a/pallets/xcmp-handler/src/tests.rs
+++ b/pallets/xcmp-handler/src/tests.rs
@@ -15,11 +15,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::{mock::*, Error, XcmChainCurrencyData, XcmCurrencyData, XcmFlow};
+use codec::Encode;
 use frame_support::{assert_noop, assert_ok, weights::constants::WEIGHT_PER_SECOND};
 use frame_system::RawOrigin;
 use polkadot_parachain::primitives::Sibling;
 use sp_runtime::traits::{AccountIdConversion, Convert};
-use xcm::latest::prelude::*;
+use xcm::{latest::prelude::*, VersionedMultiLocation};
 
 //*****************
 //Extrinsics
@@ -31,6 +32,7 @@ const XCM_DATA: XcmCurrencyData = XcmCurrencyData {
 	fee_per_second: 50_000_000_000,
 	instruction_weight: 100_000_000,
 	flow: XcmFlow::Normal,
+	location: None,
 };
 
 // add_chain_currency_data
@@ -62,6 +64,7 @@ fn add_chain_currency_data_update_data() {
 		XCM_DATA.fee_per_second,
 		XCM_DATA.instruction_weight,
 		XCM_DATA.flow,
+		Option::<VersionedMultiLocation>::encode(&XCM_DATA.location),
 	)];
 
 	new_test_ext(Some(genesis_config)).execute_with(|| {
@@ -72,6 +75,7 @@ fn add_chain_currency_data_update_data() {
 			fee_per_second: 200,
 			instruction_weight: 3_000,
 			flow: XcmFlow::Normal,
+			location: None,
 		};
 
 		assert_ok!(XcmpHandler::add_chain_currency_data(
@@ -104,6 +108,7 @@ fn remove_chain_currency_data_remove_data() {
 		XCM_DATA.fee_per_second,
 		XCM_DATA.instruction_weight,
 		XCM_DATA.flow,
+		Option::<VersionedMultiLocation>::encode(&XCM_DATA.location),
 	)];
 
 	new_test_ext(Some(genesis_config)).execute_with(|| {
@@ -145,6 +150,7 @@ fn calculate_xcm_fee_and_weight_works() {
 		XCM_DATA.fee_per_second,
 		XCM_DATA.instruction_weight,
 		XCM_DATA.flow,
+		Option::<VersionedMultiLocation>::encode(&XCM_DATA.location),
 	)];
 
 	new_test_ext(Some(genesis_config)).execute_with(|| {
@@ -166,7 +172,15 @@ fn calculate_xcm_fee_and_weight_works() {
 
 #[test]
 fn calculate_xcm_fee_and_weight_fee_overflow() {
-	let gensis_config = vec![(PARA_ID, NATIVE, false, u128::MAX, 1_000, XcmFlow::Normal)];
+	let gensis_config = vec![(
+		PARA_ID,
+		NATIVE,
+		false,
+		u128::MAX,
+		1_000,
+		XcmFlow::Normal,
+		Option::<VersionedMultiLocation>::encode(&None),
+	)];
 
 	new_test_ext(Some(gensis_config)).execute_with(|| {
 		let transact_encoded_call_weight: u64 = 100_000_000;
@@ -184,7 +198,15 @@ fn calculate_xcm_fee_and_weight_fee_overflow() {
 
 #[test]
 fn calculate_xcm_fee_and_weight_weight_overflow() {
-	let gensis_config = vec![(PARA_ID, NATIVE, false, 1_000, u64::MAX, XcmFlow::Normal)];
+	let gensis_config = vec![(
+		PARA_ID,
+		NATIVE,
+		false,
+		1_000,
+		u64::MAX,
+		XcmFlow::Normal,
+		Option::<VersionedMultiLocation>::encode(&None),
+	)];
 
 	new_test_ext(Some(gensis_config)).execute_with(|| {
 		let transact_encoded_call_weight: u64 = u64::MAX;
@@ -229,6 +251,7 @@ fn calculate_xcm_fee_handles_alternate_flow() {
 		XCM_DATA.fee_per_second,
 		XCM_DATA.instruction_weight,
 		XcmFlow::Alternate,
+		Option::<VersionedMultiLocation>::encode(&XCM_DATA.location),
 	)];
 
 	new_test_ext(Some(genesis_config)).execute_with(|| {
@@ -275,6 +298,7 @@ fn get_instruction_set_local_currency_instructions() {
 		XCM_DATA.fee_per_second,
 		XCM_DATA.instruction_weight,
 		XCM_DATA.flow,
+		Option::<VersionedMultiLocation>::encode(&XCM_DATA.location),
 	)];
 
 	new_test_ext(Some(genesis_config)).execute_with(|| {
@@ -288,13 +312,19 @@ fn get_instruction_set_local_currency_instructions() {
 		.unwrap();
 		let descend_location: Junctions =
 			AccountIdToMultiLocation::convert(ALICE).try_into().unwrap();
+
+		let target_asset = MultiAsset {
+			id: Concrete(MultiLocation::new(0, Here)),
+			fun: Fungibility::Fungible(xcm_fee),
+		};
+
 		let expected_instructions = XcmpHandler::get_local_currency_instructions(
 			PARA_ID,
+			target_asset,
 			descend_location,
 			transact_encoded_call.clone(),
 			transact_encoded_call_weight,
 			xcm_weight,
-			xcm_fee,
 		)
 		.unwrap();
 
@@ -324,13 +354,18 @@ fn get_local_currency_instructions_works() {
 		let descend_location: Junctions =
 			AccountIdToMultiLocation::convert(ALICE).try_into().unwrap();
 
+		let target_asset = MultiAsset {
+			id: Concrete(MultiLocation::new(0, Here)),
+			fun: Fungibility::Fungible(xcm_fee),
+		};
+
 		let (local, target) = XcmpHandler::get_local_currency_instructions(
 			PARA_ID,
+			target_asset,
 			descend_location,
 			transact_encoded_call,
 			transact_encoded_call_weight,
 			xcm_weight,
-			xcm_fee,
 		)
 		.unwrap();
 		assert_eq!(local.0.len(), 2);
@@ -352,13 +387,18 @@ fn transact_in_local_chain_works() {
 		let descend_location: Junctions =
 			AccountIdToMultiLocation::convert(ALICE).try_into().unwrap();
 
+		let target_asset = MultiAsset {
+			id: Concrete(MultiLocation::new(0, Here)),
+			fun: Fungibility::Fungible(xcm_fee),
+		};
+
 		let (local_instructions, _) = XcmpHandler::get_local_currency_instructions(
 			PARA_ID,
+			target_asset,
 			descend_location,
 			transact_encoded_call.clone(),
 			transact_encoded_call_weight,
 			xcm_weight,
-			xcm_fee,
 		)
 		.unwrap();
 
@@ -396,13 +436,18 @@ fn transact_in_target_chain_works() {
 		let descend_location: Junctions =
 			AccountIdToMultiLocation::convert(ALICE).try_into().unwrap();
 
+		let target_asset = MultiAsset {
+			id: Concrete(MultiLocation::new(0, Here)),
+			fun: Fungibility::Fungible(xcm_fee),
+		};
+
 		let (_, target_instructions) = XcmpHandler::get_local_currency_instructions(
 			PARA_ID,
+			target_asset,
 			descend_location,
 			transact_encoded_call.clone(),
 			transact_encoded_call_weight,
 			xcm_weight,
-			xcm_fee,
 		)
 		.unwrap();
 

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -566,7 +566,7 @@ parameter_types! {
 	/// Minimum stake required to become a collator
 	pub const MinCollatorStk: u128 = 400_000 * DOLLAR;
 	/// Minimum stake required to be reserved to be a candidate
-	pub const MinCandidateStk: u128 = 2_000_000 * DOLLAR;
+	pub const MinCandidateStk: u128 = 1_000_000 * DOLLAR;
 }
 impl pallet_parachain_staking::Config for Runtime {
 	type Event = Event;

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -137,7 +137,9 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	pallet_xcmp_handler::migrations::add_flow_to_currency_data::AddFlowToCurrencyData<Runtime>,
+	pallet_xcmp_handler::migrations::add_location_to_currency_data::AddLocationToCurrencyData<
+		Runtime,
+	>,
 >;
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know

--- a/zombienets/turing/moonbase.toml
+++ b/zombienets/turing/moonbase.toml
@@ -1,0 +1,47 @@
+[settings]
+provider = "native"
+timeout = 1000
+
+[relaychain]
+default_command = "../polkadot/target/release/polkadot"
+chain = "rococo-local"
+
+[[relaychain.nodes]]
+name = "alice"
+
+[[relaychain.nodes]]
+name = "bob"
+
+[[parachains]]
+id = 2114
+cumulus_based = true
+chain = "turing-dev"
+
+[parachains.collator]
+name = "turing-col-1"
+command = "./target/release/oak-collator"
+ws_port = 9946
+rpc_port = 8855
+
+[[parachains]]
+id = 1000
+cumulus_based = true
+chain = "moonbase-local"
+
+[parachains.collator]
+name = "moonbase-local-col-1"
+command = "../moonbeam/target/release/moonbeam"
+ws_port = 9949
+rpc_port = 8868
+
+[[hrmp_channels]]
+sender = 2114
+recipient = 1000
+max_capacity = 8
+max_message_size = 512
+
+[[hrmp_channels]]
+sender = 1000
+recipient = 2114
+max_capacity = 8
+max_message_size = 512


### PR DESCRIPTION
As discussed with Dawufi within ChaosDAO discord the current configuration of a 2 million minimum candidate stake on Turing network does not work out well. 
The average total backing per collator in Turing is currently around 1.25M TUR so a node joining with 2M TUR would earn less than delegating.
There currently is a vacant collator slot because Nova Wallet team left.

ChaosDAO wants to support Turing and operate a collator node for the network.

Therefore we proposed to lower the minCandidateStk to 1M TUR and created this PR to save you the work and get it applied. 