### PR TITLE
Add schedule_as into TaskScheduled event

### DIFF
--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -286,7 +286,7 @@ benchmarks! {
 		let task_id = Pallet::<T>::generate_task_id(caller.clone(), provided_id.clone());
 	}: schedule_dynamic_dispatch_task(RawOrigin::Signed(caller.clone()), provided_id, schedule, Box::new(call))
 	verify {
-		assert_last_event::<T>(Event::TaskScheduled { who: caller, task_id: task_id }.into())
+		assert_last_event::<T>(Event::TaskScheduled { who: caller, task_id: task_id, schedule_as: None }.into())
 	}
 
 	schedule_dynamic_dispatch_task_full {
@@ -312,7 +312,7 @@ benchmarks! {
 		schedule_notify_tasks::<T>(caller.clone(), times, T::MaxTasksPerSlot::get() - 1);
 	}: schedule_dynamic_dispatch_task(RawOrigin::Signed(caller.clone()), provided_id, schedule, Box::new(call))
 	verify {
-		assert_last_event::<T>(Event::TaskScheduled { who: caller, task_id: task_id }.into())
+		assert_last_event::<T>(Event::TaskScheduled { who: caller, task_id: task_id, schedule_as: None }.into())
 	}
 
 	cancel_scheduled_task_full {

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -267,6 +267,7 @@ pub mod pallet {
 		TaskScheduled {
 			who: AccountOf<T>,
 			task_id: TaskId<T>,
+			schedule_as: Option<AccountOf<T>>,
 		},
 		/// Cancelled a task.
 		TaskCancelled {
@@ -1385,12 +1386,12 @@ pub mod pallet {
 					Ok(task_id)
 				})?;
 
-			let scheduler = match action {
-				Action::XCMP { schedule_as, .. } => schedule_as.unwrap_or(owner_id),
-				_ => owner_id,
+			let schedule_as = match action {
+				Action::XCMP { schedule_as, .. } => schedule_as,
+				_ => None,
 			};
 
-			Self::deposit_event(Event::<T>::TaskScheduled { who: scheduler, task_id });
+			Self::deposit_event(Event::<T>::TaskScheduled { who: owner_id, task_id, schedule_as });
 			Ok(())
 		}
 
@@ -1439,9 +1440,18 @@ pub mod pallet {
 					})?;
 
 					let owner_id = task.owner_id.clone();
-					AccountTasks::<T>::insert(owner_id.clone(), task_id, task);
+					AccountTasks::<T>::insert(owner_id.clone(), task_id, task.clone());
 
-					Self::deposit_event(Event::<T>::TaskScheduled { who: owner_id, task_id });
+					let schedule_as = match task.action.clone() {
+						Action::XCMP { schedule_as, .. } => schedule_as.clone(),
+						_ => None,
+					};
+
+					Self::deposit_event(Event::<T>::TaskScheduled {
+						who: owner_id,
+						task_id,
+						schedule_as,
+					});
 				},
 				Schedule::Fixed { .. } => {},
 			}

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -333,6 +333,7 @@ pub mod pallet {
 		TaskRescheduled {
 			who: AccountOf<T>,
 			task_id: TaskId<T>,
+			schedule_as: Option<AccountOf<T>>,
 		},
 		/// A recurring task was not rescheduled
 		TaskNotRescheduled {
@@ -1409,9 +1410,18 @@ pub mod pallet {
 				AccountTasks::<T>::remove(task.owner_id.clone(), task_id);
 			} else {
 				let owner_id = task.owner_id.clone();
+				let action = task.action.clone();
 				match Self::reschedule_existing_task(task_id, &mut task) {
 					Ok(_) => {
-						Self::deposit_event(Event::<T>::TaskRescheduled { who: owner_id, task_id });
+						let schedule_as = match action {
+							Action::XCMP { schedule_as, .. } => schedule_as,
+							_ => None,
+						};
+						Self::deposit_event(Event::<T>::TaskRescheduled {
+							who: owner_id,
+							task_id,
+							schedule_as,
+						});
 					},
 					Err(err) => {
 						Self::deposit_event(Event::<T>::TaskFailedToReschedule {

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -351,7 +351,11 @@ impl Convert<CurrencyId, Option<MultiLocation>> for MockTokenIdConvert {
 pub struct MockEnsureProxy;
 impl EnsureProxy<AccountId> for MockEnsureProxy {
 	fn ensure_ok(_delegator: AccountId, _delegatee: AccountId) -> Result<(), &'static str> {
-		Ok(())
+		if _delegator == ALICE.into() && _delegatee == BOB.into() {
+			Ok(())
+		} else {
+			Err("proxy error: expected `ProxyType::Any`")
+		}
 	}
 }
 

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -42,6 +42,9 @@ pub type CurrencyId = u32;
 
 pub const ALICE: [u8; 32] = [1u8; 32];
 pub const BOB: [u8; 32] = [2u8; 32];
+pub const DELEGATOR_ACCOUNT: [u8; 32] = [3u8; 32];
+pub const PROXY_ACCOUNT: [u8; 32] = [4u8; 32];
+
 pub const PARA_ID: u32 = 2000;
 pub const NATIVE: CurrencyId = 0;
 
@@ -351,7 +354,7 @@ impl Convert<CurrencyId, Option<MultiLocation>> for MockTokenIdConvert {
 pub struct MockEnsureProxy;
 impl EnsureProxy<AccountId> for MockEnsureProxy {
 	fn ensure_ok(_delegator: AccountId, _delegatee: AccountId) -> Result<(), &'static str> {
-		if _delegator == ALICE.into() && _delegatee == BOB.into() {
+		if _delegator == DELEGATOR_ACCOUNT.into() && _delegatee == PROXY_ACCOUNT.into() {
 			Ok(())
 		} else {
 			Err("proxy error: expected `ProxyType::Any`")

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -792,7 +792,8 @@ mod extrinsics {
 					last_event(),
 					RuntimeEvent::AutomationTime(crate::Event::TaskScheduled {
 						who: account_id,
-						task_id
+						task_id,
+						schedule_as: None,
 					})
 				);
 			})

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -350,7 +350,7 @@ fn schedule_xcmp_through_proxy_works() {
 				}) if *who == proxy_account && *schedule_as == Some(delegator_account.clone()) => true,
 				_ => false,
 			})
-			.expect("The TaskScheduled event should be emitted, with the data where who is the proxy_account, and schedule_as is the user_account.");
+			.expect("TaskScheduled event should emit with 'who' being proxy_account, and 'schedule_as' being delegator_account.");
 	})
 }
 

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -271,8 +271,8 @@ fn schedule_xcmp_works() {
 fn schedule_xcmp_through_proxy_works() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		let provided_id = vec![50];
-		let user_account = AccountId32::new(ALICE);
-		let proxy_account = AccountId32::new(BOB);
+		let delegator_account = AccountId32::new(DELEGATOR_ACCOUNT);
+		let proxy_account = AccountId32::new(PROXY_ACCOUNT);
 		let call: Vec<u8> = vec![2, 4, 5];
 
 		// Funds including XCM fees
@@ -287,7 +287,7 @@ fn schedule_xcmp_through_proxy_works() {
 			MultiLocation::new(1, X1(Parachain(PARA_ID.into()))).into(),
 			call.clone(),
 			Weight::from_ref_time(100_000),
-			user_account.clone(),
+			delegator_account.clone(),
 		));
 
 		let tasks = AutomationTime::get_scheduled_tasks(SCHEDULED_TIME);
@@ -304,7 +304,7 @@ fn schedule_xcmp_through_proxy_works() {
 					who,
 					schedule_as,
 					..
-				}) if *who == proxy_account && *schedule_as == Some(user_account.clone()) => true,
+				}) if *who == proxy_account && *schedule_as == Some(delegator_account.clone()) => true,
 				_ => false,
 			})
 			.expect("The TaskScheduled event should be emitted, with the data where who is the proxy_account, and schedule_as is the user_account.");
@@ -312,18 +312,18 @@ fn schedule_xcmp_through_proxy_works() {
 }
 
 #[test]
-fn schedule_xcmp_through_proxy_same_as_user_account() {
+fn schedule_xcmp_through_proxy_same_as_delegator_account() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		let provided_id = vec![50];
-		let user_account = AccountId32::new(ALICE);
+		let delegator_account = AccountId32::new(ALICE);
 		let call: Vec<u8> = vec![2, 4, 5];
 
 		// Funds including XCM fees
-		get_xcmp_funds(user_account.clone());
+		get_xcmp_funds(delegator_account.clone());
 
 		assert_noop!(
 			AutomationTime::schedule_xcmp_task_through_proxy(
-				RuntimeOrigin::signed(user_account.clone()),
+				RuntimeOrigin::signed(delegator_account.clone()),
 				provided_id,
 				ScheduleParam::Fixed { execution_times: vec![SCHEDULED_TIME] },
 				PARA_ID.try_into().unwrap(),
@@ -331,7 +331,7 @@ fn schedule_xcmp_through_proxy_same_as_user_account() {
 				MultiLocation::new(1, X1(Parachain(PARA_ID.into()))).into(),
 				call.clone(),
 				Weight::from_ref_time(100_000),
-				user_account.clone(),
+				delegator_account.clone(),
 			),
 			sp_runtime::DispatchError::Other("proxy error: expected `ProxyType::Any`"),
 		);

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -312,6 +312,33 @@ fn schedule_xcmp_through_proxy_works() {
 }
 
 #[test]
+fn schedule_xcmp_through_proxy_same_as_user_account() {
+	new_test_ext(START_BLOCK_TIME).execute_with(|| {
+		let provided_id = vec![50];
+		let user_account = AccountId32::new(ALICE);
+		let call: Vec<u8> = vec![2, 4, 5];
+
+		// Funds including XCM fees
+		get_xcmp_funds(user_account.clone());
+
+		assert_noop!(
+			AutomationTime::schedule_xcmp_task_through_proxy(
+				RuntimeOrigin::signed(user_account.clone()),
+				provided_id,
+				ScheduleParam::Fixed { execution_times: vec![SCHEDULED_TIME] },
+				PARA_ID.try_into().unwrap(),
+				NATIVE,
+				MultiLocation::new(1, X1(Parachain(PARA_ID.into()))).into(),
+				call.clone(),
+				Weight::from_ref_time(100_000),
+				user_account.clone(),
+			),
+			sp_runtime::DispatchError::Other("proxy error: expected `ProxyType::Any`"),
+		);
+	})
+}
+
+#[test]
 fn schedule_xcmp_fails_if_not_enough_funds() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		let alice = AccountId32::new(ALICE);

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -198,7 +198,7 @@ impl Schedule {
 }
 
 /// The struct that stores all information needed for a task.
-#[derive(Debug, Encode, Decode, TypeInfo)]
+#[derive(Debug, Encode, Decode, TypeInfo, Clone)]
 #[scale_info(skip_type_params(MaxExecutionTimes))]
 pub struct Task<AccountId, Balance, CurrencyId> {
 	pub owner_id: AccountId,


### PR DESCRIPTION
Fixed the problem that when calling `scheduleXcmpTaskThroughProxy`, the `who` parameter of TaskScheduled was inconsistent with `AccountId32` in `automationTime.accountTasks` in storage.

`who` is always the caller for extrinsic.

<img width="460" alt="image" src="https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/a5fcfbf9-4197-4a80-a4ea-73793d419b84">

<img width="843" alt="image" src="https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/3007414c-6c41-456a-be3a-02b138446c97">

