### PR TITLE
add stale activity checker

### DIFF
--- a/.github/workflows/stale_activity.yml
+++ b/.github/workflows/stale_activity.yml
@@ -1,8 +1,10 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    # 13 UTC -> 5AM PST or 6AM PDT
     - cron: '0 13 * * *'
+    - cron: '39 20 * * *'
+  workflow_dispatch:
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
add a stale checker run on giuthub action cronjob to remind and auto close issue/pr that has no activity