### PR TITLE
Fix #388 - Increase scheduler pallet’s maximumSchedulerWeight to fix Democracy problem

### DIFF
--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -722,7 +722,7 @@ impl pallet_preimage::Config for Runtime {
 }
 
 parameter_types! {
-	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(10) * RuntimeBlockWeights::get().max_block;
+	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(40) * RuntimeBlockWeights::get().max_block;
 	pub const NoPreimagePostponement: Option<u32> = Some(10);
 }
 

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -742,7 +742,7 @@ impl pallet_preimage::Config for Runtime {
 }
 
 parameter_types! {
-	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(10) * RuntimeBlockWeights::get().max_block;
+	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(40) * RuntimeBlockWeights::get().max_block;
 	pub const NoPreimagePostponement: Option<u32> = Some(10);
 }
 

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -741,7 +741,7 @@ impl pallet_preimage::Config for Runtime {
 }
 
 parameter_types! {
-	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(10) * RuntimeBlockWeights::get().max_block;
+	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(40) * RuntimeBlockWeights::get().max_block;
 	pub const NoPreimagePostponement: Option<u32> = Some(10);
 }
 


### PR DESCRIPTION
The PR is trying to fix a problem where `scheduler.dispatch` event would fail due to a `scheduler.permantlyOverWeight` error since we upgraded to v1.9.0. We found the issue on Turing Staging, which blocked a governance proposal on [block 2,066,412](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc.turing-staging.oak.tech#/explorer/query/2066412)

# Solution
The root reason is that the proofSize of the constant variable `scheduler.maximumWeight` is too low, so the solution is to increase that to above 2M in code.
Expected proofSize: 1.08M
![image](https://github.com/OAK-Foundation/OAK-blockchain/assets/2616844/15f67d4b-fb1c-4e73-8d59-b3d9b3b597d5)

Current proofSize on Turing Staging: 0.52M
![image](https://github.com/OAK-Foundation/OAK-blockchain/assets/2616844/1bc37e2d-841f-4f6a-b12b-3422d9d03859)

# Testing 
The below manual tests are done in local environment using `zombienet spawn zombienets/turing/single-chain.toml`.

The same governance proposal was approved and dispatched by scheduler in the Before and After cases.
![CleanShot 2023-07-24 at 18 43 48](https://github.com/OAK-Foundation/OAK-blockchain/assets/2616844/74cbbe9b-df87-4c80-9e13-3f9f428d0c57)

## Before code update
**scheduler.maximumWeight:**
{
  refTime: 50,000,000,000
  proofSize: 524,288
}

**scheduler.dispatch Error**
![CleanShot 2023-07-24 at 18 51 40](https://github.com/OAK-Foundation/OAK-blockchain/assets/2616844/ae2ecf08-8f98-4c5b-bb2b-7f29d13131ff)

## After code update
**scheduler.maximumWeight:**
{
    refTime: 200,000,000,000,
    proofSize: 2,097,152
}

**scheduler.dispatch Success**
![CleanShot 2023-07-24 at 18 10 36](https://github.com/OAK-Foundation/OAK-blockchain/assets/2616844/ab135ee7-cce2-4067-aef3-dfbcf630b762)
