### PR TITLE
Fix xcmp return weight

### DIFF
--- a/pallets/automation-time/src/migrations/update_xcmp_task.rs
+++ b/pallets/automation-time/src/migrations/update_xcmp_task.rs
@@ -6,8 +6,9 @@ use crate::{
 #[cfg(feature = "try-runtime")]
 use codec::{Decode, Encode};
 use frame_support::{
-    traits::{ Get, OnRuntimeUpgrade}, Twox64Concat,
+	traits::{Get, OnRuntimeUpgrade},
 	weights::{RuntimeDbWeight, Weight},
+	Twox64Concat,
 };
 use sp_runtime::traits::Convert;
 use sp_std::{vec, vec::Vec};


### PR DESCRIPTION
the old xcmp migration task return weight from `migration_upgrade_xcmp_task`. this weight definition is being removed from our benchmark.rs in lastcode, so upon re-generate benchmark, we will lost it. 

Plus the way substrate mention is count the amount of ops we do to storage. when we loop over the task, we read/insert them back. there is one extra time where we access the whole Storage itself.