### PR TITLE
accept list of pallet for benchmark action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
           # Matrix only take a list so we use fromJSON to convert raw json string data to list
           # The input is from Github action input, which doesn't support list so we take raw string separate by ','
           # Convert the string a,b,c -> a json array ["a", "b", "c"] with bracket and double quote properly
-          echo "{pallet}={$(echo -n ${{ inputs.pallet }} | jq --raw-input --slurp 'split(",")' -c)}" >> $GITHUB_OUTPUT
+          echo "pallet=$(echo -n ${{ inputs.pallet }} | jq --raw-input --slurp 'split(",")' -c)" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
 
   build-binary:


### PR DESCRIPTION
when benchmark is being removed between different branch/tag the benchmark may failed to run without updating the hard code list of pallet in github action.

We now accept list of pallet to benchmark from the action input.

Example of failure due to removing benchmark in xcmp 

https://github.com/OAK-Foundation/OAK-blockchain/actions/runs/5755356040/job/15602990553

![Screenshot 2023-08-03 at 3 27 38 PM](https://github.com/OAK-Foundation/OAK-blockchain/assets/49754/c2ad5a50-3974-4833-8693-6bc413a34029)
