### PR TITLE
Modify the execution fee of the Mangata XCMP task in the migration

### DIFF
--- a/pallets/automation-time/src/migrations/update_xcmp_task.rs
+++ b/pallets/automation-time/src/migrations/update_xcmp_task.rs
@@ -19,7 +19,7 @@ use crate::migrations::utils::{
 	OldAccountTaskId, OldAction, OldTask, OldTaskId, TEST_TASKID1,
 };
 
-const EXECUTION_FEE_AMOUNT: u128 = 3_000_000_000;
+const EXECUTION_FEE_AMOUNT: u128 = 4_000_000_000;
 const INSTRUCTION_WEIGHT_REF_TIME: u64 = 150_000_000;
 
 impl<T: Config> From<OldAction<T>> for ActionOf<T> {


### PR DESCRIPTION
Due to some changes in the new version of Mangata's code (runtime-3001), there have been adjustments to fee_per_second in the chain spec of the local environment. This has led to situations where Mangata XCMP tasks fail to execute successfully (due to insufficient fee, resulting in "TooExpensive" error) on the Mangata chain after migration in the local test environment.

To address this issue, we need to slightly increase the execution fee to ensure that the tasks can be successfully executed.

fee_per_second
mangata-local: 871,400,000,000
mangata-rococo: 537,600,000,000
mangata-kusama: 537,600,000,000

We need to slightly increase the execution fee to ensure that the tasks can be successfully executed.

Since it is configured in the chain spec and saved in storage, the configuration is no changed after the chain is launched.

mangata-local:
![image](https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/da027458-fcc5-4ac4-97d5-761c756e4b20)

mangata-kusama:
![image](https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/56a59fda-9a82-4639-8c21-62822bb491e4)
