### PR TITLE
Fix #414 rename turing docker image release action

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,4 +1,4 @@
-name: Relase Docker Image
+name: Publish Turing Docker Image
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Cleanup and standrize our action name to publish image for 

- turing dev image (with dev-queue enabled)
- turing chain image (using on turing staging or turing production)


