### PR TITLE
Remove refund instructions

### DIFF
--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -310,11 +310,6 @@ pub mod pallet {
 					require_weight_at_most: transact_encoded_call_weight,
 					call: transact_encoded_call.into(),
 				},
-				RefundSurplus::<()>,
-				DepositAsset::<()> {
-					assets: Wild(AllCounted(1)),
-					beneficiary: MultiLocation { parents: 1, interior: descend_location },
-				},
 			]);
 
 			Ok((Xcm(vec![]), target_xcm))


### PR DESCRIPTION
The reason of these removal is that each XCM instruction costs 1M weight, so removing the last two for refunding actually will cost users less than having a refund process.

Besides, Rocstar doesn’t allow high XCM weight per block, so reducing weight of each XCM messages will help our messages get unblocked.