### PR TITLE
Adjust automation time slot

### DIFF
--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -609,7 +609,8 @@ pub mod pallet {
 			}
 
 			let now = now.checked_div(1000).ok_or(ArithmeticError::Overflow)?;
-			let diff_to_slot = now.checked_rem(T::SlotPeriod::get()).ok_or(ArithmeticError::Overflow)?;
+			let diff_to_slot =
+				now.checked_rem(T::SlotPeriod::get()).ok_or(ArithmeticError::Overflow)?;
 			Ok(now.checked_sub(diff_to_slot).ok_or(ArithmeticError::Overflow)?)
 		}
 
@@ -625,7 +626,9 @@ pub mod pallet {
 				return Ok(())
 			}
 
-			let remainder = scheduled_time.checked_rem(T::SlotPeriod::get()).ok_or(ArithmeticError::Overflow)?;
+			let remainder = scheduled_time
+				.checked_rem(T::SlotPeriod::get())
+				.ok_or(ArithmeticError::Overflow)?;
 			if remainder != 0 {
 				Err(<Error<T>>::InvalidTime)?;
 			}
@@ -795,8 +798,8 @@ pub mod pallet {
 					allotted_weight,
 				);
 
-				let last_missed_slot_tracker =
-					last_missed_slot.saturating_add(missed_slots_moved.saturating_mul(T::SlotPeriod::get()));
+				let last_missed_slot_tracker = last_missed_slot
+					.saturating_add(missed_slots_moved.saturating_mul(T::SlotPeriod::get()));
 				let used_weight = append_weight;
 				(last_missed_slot_tracker, used_weight)
 			} else {
@@ -815,8 +818,9 @@ pub mod pallet {
 		) -> (Weight, u64) {
 			// will need to move task queue into missed queue
 			let mut missed_tasks = vec![];
-			let mut diff =
-				(current_time_slot.saturating_sub(last_missed_slot) / T::SlotPeriod::get()).saturating_sub(1);
+			let mut diff = (current_time_slot.saturating_sub(last_missed_slot) /
+				T::SlotPeriod::get())
+			.saturating_sub(1);
 			for i in 0..diff {
 				if allotted_weight.ref_time() <
 					<T as Config>::WeightInfo::shift_missed_tasks().ref_time()

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -236,7 +236,7 @@ pub mod pallet {
 	#[pallet::error]
 	#[derive(PartialEq)]
 	pub enum Error<T> {
-		/// Time must end in a whole SlotSizeSeconds.
+		/// Time in seconds must be a multiple of SlotSizeSeconds
 		InvalidTime,
 		/// Time must be in the future.
 		PastTime,
@@ -365,7 +365,7 @@ pub mod pallet {
 		/// * `overall_weight`: The overall weight in which fees will be paid for XCM instructions.
 		///
 		/// # Errors
-		/// * `InvalidTime`: Time must end in a whole SlotSizeSeconds.
+		/// * `InvalidTime`: Time in seconds must be a multiple of SlotSizeSeconds.
 		/// * `PastTime`: Time must be in the future.
 		/// * `DuplicateTask`: There can be no duplicate tasks.
 		/// * `TimeTooFarOut`: Execution time or frequency are past the max time horizon.
@@ -422,7 +422,7 @@ pub mod pallet {
 		/// * `overall_weight`: The overall weight in which fees will be paid for XCM instructions.
 		///
 		/// # Errors
-		/// * `InvalidTime`: Time must end in a whole SlotSizeSeconds.
+		/// * `InvalidTime`: Time in seconds must be a multiple of SlotSizeSeconds.
 		/// * `PastTime`: Time must be in the future.
 		/// * `DuplicateTask`: There can be no duplicate tasks.
 		/// * `TimeTooFarOut`: Execution time or frequency are past the max time horizon.
@@ -478,7 +478,7 @@ pub mod pallet {
 		/// * `account_minimum`: The minimum amount of funds that should be left in the wallet
 		///
 		/// # Errors
-		/// * `InvalidTime`: Execution time and frequency must end in a whole SlotSizeSeconds.
+		/// * `InvalidTime`: Execution time and frequency must be a multiple of SlotSizeSeconds.
 		/// * `PastTime`: Time must be in the future.
 		/// * `DuplicateTask`: There can be no duplicate tasks.
 		/// * `TimeSlotFull`: Time slot is full. No more tasks can be scheduled for this time.
@@ -520,7 +520,7 @@ pub mod pallet {
 		/// * `call`: The call that will be dispatched.
 		///
 		/// # Errors
-		/// * `InvalidTime`: Execution time and frequency must end in a whole SlotSizeSeconds.
+		/// * `InvalidTime`: Execution time and frequency must be a multiple of SlotSizeSeconds.
 		/// * `PastTime`: Time must be in the future.
 		/// * `DuplicateTask`: There can be no duplicate tasks.
 		/// * `TimeSlotFull`: Time slot is full. No more tasks can be scheduled for this time.
@@ -613,7 +613,7 @@ pub mod pallet {
 		/// Checks to see if the scheduled time is valid.
 		///
 		/// In order for a time to be valid it must
-		/// - End in a whole SlotSizeSeconds
+		/// - A multiple of SlotSizeSeconds
 		/// - Be in the future
 		/// - Not be more than MaxScheduleSeconds out
 		pub fn is_valid_time(scheduled_time: UnixTime) -> DispatchResult {

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -17,11 +17,7 @@
 
 //! # Automation time pallet
 //!
-//! DISCLAIMER: This pallet is still in it's early stages. At this point
-//! we only support scheduling two tasks per SlotPeriod, and sending an on-chain
-//! with a custom message.
-//!
-//! This pallet allows a user to schedule tasks. Tasks can scheduled for any whole SlotPeriod in the future.
+//! This pallet allows a user to schedule tasks. Tasks can scheduled for any whole SlotSizeSeconds in the future.
 //! In order to run tasks this pallet consumes up to a certain amount of weight during `on_initialize`.
 //!
 //! The pallet supports the following tasks:
@@ -133,9 +129,9 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxWeightPerSlot: Get<u128>;
 
-		/// Seconds per slot
+		/// The minimum time interval tasks could schedule for. For example, if the value is 600, then only inputs that are multiples of 600 are allowed. In other words, tasks can only be scheduled at 0, 10, 20 ... minutes of each hour.
 		#[pallet::constant]
-		type SlotPeriod: Get<u64>;
+		type SlotSizeSeconds: Get<u64>;
 
 		/// The maximum percentage of weight per block used for scheduled tasks.
 		#[pallet::constant]
@@ -240,7 +236,7 @@ pub mod pallet {
 	#[pallet::error]
 	#[derive(PartialEq)]
 	pub enum Error<T> {
-		/// Time must end in a whole SlotPeriod.
+		/// Time must end in a whole SlotSizeSeconds.
 		InvalidTime,
 		/// Time must be in the future.
 		PastTime,
@@ -369,7 +365,7 @@ pub mod pallet {
 		/// * `overall_weight`: The overall weight in which fees will be paid for XCM instructions.
 		///
 		/// # Errors
-		/// * `InvalidTime`: Time must end in a whole SlotPeriod.
+		/// * `InvalidTime`: Time must end in a whole SlotSizeSeconds.
 		/// * `PastTime`: Time must be in the future.
 		/// * `DuplicateTask`: There can be no duplicate tasks.
 		/// * `TimeTooFarOut`: Execution time or frequency are past the max time horizon.
@@ -426,7 +422,7 @@ pub mod pallet {
 		/// * `overall_weight`: The overall weight in which fees will be paid for XCM instructions.
 		///
 		/// # Errors
-		/// * `InvalidTime`: Time must end in a whole SlotPeriod.
+		/// * `InvalidTime`: Time must end in a whole SlotSizeSeconds.
 		/// * `PastTime`: Time must be in the future.
 		/// * `DuplicateTask`: There can be no duplicate tasks.
 		/// * `TimeTooFarOut`: Execution time or frequency are past the max time horizon.
@@ -482,7 +478,7 @@ pub mod pallet {
 		/// * `account_minimum`: The minimum amount of funds that should be left in the wallet
 		///
 		/// # Errors
-		/// * `InvalidTime`: Execution time and frequency must end in a whole SlotPeriod.
+		/// * `InvalidTime`: Execution time and frequency must end in a whole SlotSizeSeconds.
 		/// * `PastTime`: Time must be in the future.
 		/// * `DuplicateTask`: There can be no duplicate tasks.
 		/// * `TimeSlotFull`: Time slot is full. No more tasks can be scheduled for this time.
@@ -524,7 +520,7 @@ pub mod pallet {
 		/// * `call`: The call that will be dispatched.
 		///
 		/// # Errors
-		/// * `InvalidTime`: Execution time and frequency must end in a whole SlotPeriod.
+		/// * `InvalidTime`: Execution time and frequency must end in a whole SlotSizeSeconds.
 		/// * `PastTime`: Time must be in the future.
 		/// * `DuplicateTask`: There can be no duplicate tasks.
 		/// * `TimeSlotFull`: Time slot is full. No more tasks can be scheduled for this time.
@@ -598,7 +594,7 @@ pub mod pallet {
 		/// In order to do this we:
 		/// * Get the most recent timestamp from the block.
 		/// * Convert the ms unix timestamp to seconds.
-		/// * Bring the timestamp down to the last whole SlotPeriod.
+		/// * Bring the timestamp down to the last whole SlotSizeSeconds.
 		pub fn get_current_time_slot() -> Result<UnixTime, DispatchError> {
 			let now = <timestamp::Pallet<T>>::get()
 				.checked_into::<UnixTime>()
@@ -610,14 +606,14 @@ pub mod pallet {
 
 			let now = now.checked_div(1000).ok_or(ArithmeticError::Overflow)?;
 			let diff_to_slot =
-				now.checked_rem(T::SlotPeriod::get()).ok_or(ArithmeticError::Overflow)?;
+				now.checked_rem(T::SlotSizeSeconds::get()).ok_or(ArithmeticError::Overflow)?;
 			Ok(now.checked_sub(diff_to_slot).ok_or(ArithmeticError::Overflow)?)
 		}
 
 		/// Checks to see if the scheduled time is valid.
 		///
 		/// In order for a time to be valid it must
-		/// - End in a whole SlotPeriod
+		/// - End in a whole SlotSizeSeconds
 		/// - Be in the future
 		/// - Not be more than MaxScheduleSeconds out
 		pub fn is_valid_time(scheduled_time: UnixTime) -> DispatchResult {
@@ -627,7 +623,7 @@ pub mod pallet {
 			}
 
 			let remainder = scheduled_time
-				.checked_rem(T::SlotPeriod::get())
+				.checked_rem(T::SlotSizeSeconds::get())
 				.ok_or(ArithmeticError::Overflow)?;
 			if remainder != 0 {
 				Err(<Error<T>>::InvalidTime)?;
@@ -799,7 +795,7 @@ pub mod pallet {
 				);
 
 				let last_missed_slot_tracker = last_missed_slot
-					.saturating_add(missed_slots_moved.saturating_mul(T::SlotPeriod::get()));
+					.saturating_add(missed_slots_moved.saturating_mul(T::SlotSizeSeconds::get()));
 				let used_weight = append_weight;
 				(last_missed_slot_tracker, used_weight)
 			} else {
@@ -819,7 +815,7 @@ pub mod pallet {
 			// will need to move task queue into missed queue
 			let mut missed_tasks = vec![];
 			let mut diff = (current_time_slot.saturating_sub(last_missed_slot) /
-				T::SlotPeriod::get())
+				T::SlotSizeSeconds::get())
 			.saturating_sub(1);
 			for i in 0..diff {
 				if allotted_weight.ref_time() <
@@ -851,7 +847,7 @@ pub mod pallet {
 			number_of_missed_slots: u64,
 		) -> Vec<MissedTaskV2Of<T>> {
 			let mut tasks = vec![];
-			let seconds_in_slot = T::SlotPeriod::get();
+			let seconds_in_slot = T::SlotSizeSeconds::get();
 			let shift = seconds_in_slot.saturating_mul(number_of_missed_slots + 1);
 			let new_time_slot = last_missed_slot.saturating_add(shift);
 			if let Some(ScheduledTasksOf::<T> { tasks: account_task_ids, .. }) =

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -22,7 +22,7 @@ use crate::TaskIdV2;
 use frame_benchmarking::frame_support::assert_ok;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{ConstU128, ConstU64, ConstU32, Everything},
+	traits::{ConstU128, ConstU32, ConstU64, Everything},
 	weights::Weight,
 	PalletId,
 };

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -57,6 +57,9 @@ pub const NATIVE_LOCATION: MultiLocation = MultiLocation { parents: 0, interior:
 pub const NATIVE_EXECUTION_WEIGHT_FEE: u128 = 12;
 pub const FOREIGN_CURRENCY_ID: CurrencyId = 1;
 
+pub const AUTOMATION_TIME_SLOT_PERIOD: u64 = 600;
+pub const AUTOMATION_TIME_MAX_SCHEDULE_SECONDS: u64 = 1 * 24 * 60 * 60;
+
 const DOLLAR: u128 = 10_000_000_000;
 
 pub const MOONBASE_ASSET_LOCATION: MultiLocation =
@@ -289,7 +292,7 @@ parameter_types! {
 	pub const MaxTasksPerSlot: u32 = 2;
 	#[derive(Debug)]
 	pub const MaxExecutionTimes: u32 = 3;
-	pub const MaxScheduleSeconds: u64 = 1 * 24 * 60 * 60;
+	pub const MaxScheduleSeconds: u64 = AUTOMATION_TIME_MAX_SCHEDULE_SECONDS;
 	pub const MaxBlockWeight: u64 = 20_000_000;
 	pub const MaxWeightPercentage: Perbill = Perbill::from_percent(40);
 	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
@@ -513,7 +516,7 @@ impl pallet_automation_time::Config for Test {
 	type WeightInfo = MockWeight<Test>;
 	type ExecutionWeightFee = ExecutionWeightFee;
 	type MaxWeightPerSlot = MaxWeightPerSlot;
-	type SlotPeriod = ConstU64<600>;
+	type SlotPeriod = ConstU64<AUTOMATION_TIME_SLOT_PERIOD>;
 	type Currency = Balances;
 	type MultiCurrency = Currencies;
 	type CurrencyId = CurrencyId;

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -22,7 +22,7 @@ use crate::TaskIdV2;
 use frame_benchmarking::frame_support::assert_ok;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{ConstU128, ConstU32, ConstU64, Everything},
+	traits::{ConstU128, ConstU32, Everything},
 	weights::Weight,
 	PalletId,
 };
@@ -56,9 +56,6 @@ pub const NATIVE: CurrencyId = 0;
 pub const NATIVE_LOCATION: MultiLocation = MultiLocation { parents: 0, interior: Here };
 pub const NATIVE_EXECUTION_WEIGHT_FEE: u128 = 12;
 pub const FOREIGN_CURRENCY_ID: CurrencyId = 1;
-
-pub const AUTOMATION_TIME_SLOT_PERIOD: u64 = 600;
-pub const AUTOMATION_TIME_MAX_SCHEDULE_SECONDS: u64 = 1 * 24 * 60 * 60;
 
 const DOLLAR: u128 = 10_000_000_000;
 
@@ -288,34 +285,6 @@ impl<
 	}
 }
 
-parameter_types! {
-	pub const MaxTasksPerSlot: u32 = 2;
-	#[derive(Debug)]
-	pub const MaxExecutionTimes: u32 = 3;
-	pub const MaxScheduleSeconds: u64 = AUTOMATION_TIME_MAX_SCHEDULE_SECONDS;
-	pub const MaxBlockWeight: u64 = 20_000_000;
-	pub const MaxWeightPercentage: Perbill = Perbill::from_percent(40);
-	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
-	pub const ExecutionWeightFee: Balance = NATIVE_EXECUTION_WEIGHT_FEE;
-
-	// When unit testing dynamic dispatch, we use the real weight value of the extrinsics call
-	// This is an external lib that we don't own so we try to not mock, follow the rule don't mock
-	// what you don't own
-	// One of test we do is Balances::transfer call, which has its weight define here:
-	// https://github.com/paritytech/substrate/blob/polkadot-v0.9.38/frame/balances/src/weights.rs#L61-L73
-	// When logging the final calculated amount, its value is 73_314_000.
-	//
-	// in our unit test, we test a few transfers with dynamic dispatch. On top
-	// of that, there is also weight of our call such as fetching the tasks,
-	// move from schedule slot to tasks queue,.. so the weight of a schedule
-	// transfer with dynamic dispatch is even higher.
-	//
-	// and because we test run a few of them so I set it to ~10x value of 73_314_000
-	pub const MaxWeightPerSlot: u128 = 700_000_000;
-	pub const XmpFee: u128 = 1_000_000;
-	pub const GetNativeCurrencyId: CurrencyId = NATIVE;
-}
-
 pub struct MockPalletBalanceWeight<T>(PhantomData<T>);
 impl<Test: frame_system::Config> pallet_balances::WeightInfo for MockPalletBalanceWeight<Test> {
 	fn transfer() -> Weight {
@@ -499,6 +468,32 @@ impl TransferCallCreator<MultiAddress<AccountId, ()>, Balance, RuntimeCall>
 }
 
 parameter_types! {
+	pub const MaxTasksPerSlot: u32 = 2;
+	#[derive(Debug)]
+	pub const MaxExecutionTimes: u32 = 3;
+	pub const MaxScheduleSeconds: u64 = 86_400;	// 24 hours in seconds
+	pub const SlotSizeSeconds: u64 = 600;		// 10 minutes in seconds;
+	pub const MaxBlockWeight: u64 = 20_000_000;
+	pub const MaxWeightPercentage: Perbill = Perbill::from_percent(40);
+	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
+	pub const ExecutionWeightFee: Balance = NATIVE_EXECUTION_WEIGHT_FEE;
+
+	// When unit testing dynamic dispatch, we use the real weight value of the extrinsics call
+	// This is an external lib that we don't own so we try to not mock, follow the rule don't mock
+	// what you don't own
+	// One of test we do is Balances::transfer call, which has its weight define here:
+	// https://github.com/paritytech/substrate/blob/polkadot-v0.9.38/frame/balances/src/weights.rs#L61-L73
+	// When logging the final calculated amount, its value is 73_314_000.
+	//
+	// in our unit test, we test a few transfers with dynamic dispatch. On top
+	// of that, there is also weight of our call such as fetching the tasks,
+	// move from schedule slot to tasks queue,.. so the weight of a schedule
+	// transfer with dynamic dispatch is even higher.
+	//
+	// and because we test run a few of them so I set it to ~10x value of 73_314_000
+	pub const MaxWeightPerSlot: u128 = 700_000_000;
+	pub const XmpFee: u128 = 1_000_000;
+	pub const GetNativeCurrencyId: CurrencyId = NATIVE;
 	pub const RelayNetwork: NetworkId = NetworkId::Rococo;
 	// The universal location within the global consensus system
 	pub UniversalLocation: InteriorMultiLocation =
@@ -516,7 +511,7 @@ impl pallet_automation_time::Config for Test {
 	type WeightInfo = MockWeight<Test>;
 	type ExecutionWeightFee = ExecutionWeightFee;
 	type MaxWeightPerSlot = MaxWeightPerSlot;
-	type SlotPeriod = ConstU64<AUTOMATION_TIME_SLOT_PERIOD>;
+	type SlotSizeSeconds = SlotSizeSeconds;
 	type Currency = Balances;
 	type MultiCurrency = Currencies;
 	type CurrencyId = CurrencyId;

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -22,7 +22,7 @@ use crate::TaskIdV2;
 use frame_benchmarking::frame_support::assert_ok;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{ConstU128, ConstU32, Everything},
+	traits::{ConstU128, ConstU64, ConstU32, Everything},
 	weights::Weight,
 	PalletId,
 };
@@ -513,6 +513,7 @@ impl pallet_automation_time::Config for Test {
 	type WeightInfo = MockWeight<Test>;
 	type ExecutionWeightFee = ExecutionWeightFee;
 	type MaxWeightPerSlot = MaxWeightPerSlot;
+	type SlotPeriod = ConstU64<600>;
 	type Currency = Balances;
 	type MultiCurrency = Currencies;
 	type CurrencyId = CurrencyId;

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -41,7 +41,7 @@ use xcm::latest::{prelude::*, Junction::Parachain, MultiLocation};
 use pallet_valve::Shutdown;
 
 pub const START_BLOCK_TIME: u64 = 33198768000 * 1_000;
-pub const SCHEDULED_TIME: u64 = START_BLOCK_TIME / 1_000 + 7200;
+pub const SCHEDULED_TIME: u64 = START_BLOCK_TIME / 1_000 + AUTOMATION_TIME_SLOT_PERIOD * 2;
 const LAST_BLOCK_TIME: u64 = START_BLOCK_TIME / 1_000;
 
 // This is 1-0-3: {1: block idx}-{0: first extrinsic in block}-{3: the event index}
@@ -211,8 +211,8 @@ fn schedule_invalid_time_recurring_schedule() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		for (next_run, frequency) in vec![
 			(SCHEDULED_TIME + 10, 10_u64),
-			(SCHEDULED_TIME + 3600, 100_u64),
-			(SCHEDULED_TIME + 10, 3600_u64),
+			(SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD, 100_u64),
+			(SCHEDULED_TIME + 10, AUTOMATION_TIME_SLOT_PERIOD),
 		]
 		.iter()
 		{
@@ -237,7 +237,7 @@ fn schedule_invalid_time_recurring_schedule() {
 // past an error is return and the tasks won't be scheduled
 #[test]
 fn schedule_past_time() {
-	new_test_ext(START_BLOCK_TIME + 1_000 * 10800).execute_with(|| {
+	new_test_ext(START_BLOCK_TIME + 1_000 * AUTOMATION_TIME_SLOT_PERIOD * 3).execute_with(|| {
 		assert_noop!(
 			AutomationTime::schedule_dynamic_dispatch_task(
 				RuntimeOrigin::signed(AccountId32::new(ALICE)),
@@ -250,7 +250,9 @@ fn schedule_past_time() {
 		assert_noop!(
 			AutomationTime::schedule_dynamic_dispatch_task(
 				RuntimeOrigin::signed(AccountId32::new(ALICE)),
-				ScheduleParam::Fixed { execution_times: vec![SCHEDULED_TIME - 3600] },
+				ScheduleParam::Fixed {
+					execution_times: vec![SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD]
+				},
 				Box::new(frame_system::Call::remark { remark: vec![12] }.into())
 			),
 			Error::<Test>::PastTime,
@@ -262,9 +264,12 @@ fn schedule_past_time() {
 // an error is return and the tasks won't be scheduled
 #[test]
 fn schedule_past_time_recurring() {
-	new_test_ext(START_BLOCK_TIME + 1_000 * 10800).execute_with(|| {
-		for (next_run, frequency) in
-			vec![(SCHEDULED_TIME - 3600, 7200_u64), (SCHEDULED_TIME, 7200_u64)].iter()
+	new_test_ext(START_BLOCK_TIME + 1_000 * AUTOMATION_TIME_SLOT_PERIOD * 3).execute_with(|| {
+		for (next_run, frequency) in vec![
+			(SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD, AUTOMATION_TIME_SLOT_PERIOD * 2),
+			(SCHEDULED_TIME, AUTOMATION_TIME_SLOT_PERIOD * 2),
+		]
+		.iter()
 		{
 			// prepare data
 			let call: RuntimeCall = frame_system::Call::remark { remark: vec![12] }.into();
@@ -295,21 +300,26 @@ fn schedule_too_far_out() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		for task_far_schedule in vec![
 			// only one time slot that is far
-			ScheduleParam::Fixed { execution_times: vec![SCHEDULED_TIME + 1 * 24 * 60 * 60] },
+			ScheduleParam::Fixed {
+				execution_times: vec![SCHEDULED_TIME + AUTOMATION_TIME_MAX_SCHEDULE_SECONDS],
+			},
 			// the first time slot is close, but the rest are too far
 			ScheduleParam::Fixed {
-				execution_times: vec![SCHEDULED_TIME, SCHEDULED_TIME + 1 * 24 * 60 * 60],
+				execution_times: vec![
+					SCHEDULED_TIME,
+					SCHEDULED_TIME + AUTOMATION_TIME_MAX_SCHEDULE_SECONDS,
+				],
 			},
 			// the next_execution_time is too far
 			ScheduleParam::Recurring {
-				next_execution_time: SCHEDULED_TIME + 1 * 24 * 60 * 60,
-				frequency: 3600,
+				next_execution_time: SCHEDULED_TIME + AUTOMATION_TIME_MAX_SCHEDULE_SECONDS,
+				frequency: AUTOMATION_TIME_SLOT_PERIOD,
 			},
 			// the next_execution_time is closed, but frequency is too big, make it further to
 			// future
 			ScheduleParam::Recurring {
 				next_execution_time: SCHEDULED_TIME,
-				frequency: 7 * 24 * 3600,
+				frequency: 7 * AUTOMATION_TIME_MAX_SCHEDULE_SECONDS,
 			},
 		]
 		.iter()
@@ -403,7 +413,7 @@ fn schedule_transfer_with_dynamic_dispatch() {
 #[test]
 fn will_emit_task_completed_event_when_task_completed() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
-		let frequency = 3_600;
+		let frequency = AUTOMATION_TIME_SLOT_PERIOD;
 		let account_id = AccountId32::new(ALICE);
 		let _task_id = FIRST_TASK_ID.to_vec();
 
@@ -453,7 +463,7 @@ fn will_emit_task_completed_event_when_task_completed() {
 #[test]
 fn will_not_emit_task_completed_event_when_task_canceled() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
-		let frequency = 3_600;
+		let frequency = AUTOMATION_TIME_SLOT_PERIOD;
 		let account_id = AccountId32::new(ALICE);
 		let task_id = FIRST_TASK_ID.to_vec();
 
@@ -508,7 +518,7 @@ fn will_not_emit_task_completed_event_when_task_canceled() {
 #[test]
 fn will_emit_task_completed_event_when_task_failed() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
-		let frequency = 3_600;
+		let frequency = AUTOMATION_TIME_SLOT_PERIOD;
 		let account_id = AccountId32::new(ALICE);
 		let task_id = FIRST_TASK_ID.to_vec();
 
@@ -952,7 +962,7 @@ fn schedule_auto_compound_delegated_stake() {
 		assert_ok!(AutomationTime::schedule_auto_compound_delegated_stake_task(
 			RuntimeOrigin::signed(alice.clone()),
 			SCHEDULED_TIME,
-			3_600,
+			AUTOMATION_TIME_SLOT_PERIOD,
 			bob.clone(),
 			1_000_000_000,
 		));
@@ -966,7 +976,7 @@ fn schedule_auto_compound_delegated_stake() {
 				alice.clone(),
 				FIRST_TASK_ID.to_vec(),
 				SCHEDULED_TIME,
-				3_600,
+				AUTOMATION_TIME_SLOT_PERIOD,
 				bob,
 				1_000_000_000,
 				vec![],
@@ -979,7 +989,7 @@ fn schedule_auto_compound_delegated_stake() {
 // Auto compounding use Recurring schedule to perform tasks.
 // Thus the next_execution_time and frequency needs to follow the rule such as
 // next_execution_time needs to fall into beginning of a hour block, and
-// frequency must be a multiplier of 3600
+// frequency must be a multiplier of AUTOMATION_TIME_SLOT_PERIOD
 #[test]
 fn schedule_auto_compound_with_bad_frequency_or_execution_time() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
@@ -988,7 +998,7 @@ fn schedule_auto_compound_with_bad_frequency_or_execution_time() {
 			(SCHEDULED_TIME, 4_000),
 			(SCHEDULED_TIME, 0),
 			// execute_with is invalid, frequency is  valid
-			(SCHEDULED_TIME + 3130, 3600),
+			(SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD / 2, AUTOMATION_TIME_SLOT_PERIOD),
 		]
 		.iter()
 		{
@@ -1012,8 +1022,11 @@ fn schedule_auto_compound_with_bad_frequency_or_execution_time() {
 fn schedule_auto_compound_with_high_frequency() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		for (execution_time, frequency) in vec![
-			(SCHEDULED_TIME, <Test as Config>::MaxScheduleSeconds::get() + 3_600),
-			(SCHEDULED_TIME + 7 * 24 * 3600, 3_600),
+			(
+				SCHEDULED_TIME,
+				<Test as Config>::MaxScheduleSeconds::get() + AUTOMATION_TIME_SLOT_PERIOD,
+			),
+			(SCHEDULED_TIME + 7 * 24 * AUTOMATION_TIME_SLOT_PERIOD, AUTOMATION_TIME_SLOT_PERIOD),
 		]
 		.iter()
 		{
@@ -1041,7 +1054,7 @@ fn get_auto_compound_delegated_stake_task_ids_return_only_auto_compount_task_id(
 		assert_ok!(AutomationTime::schedule_auto_compound_delegated_stake_task(
 			RuntimeOrigin::signed(owner.clone()),
 			SCHEDULED_TIME,
-			3_600,
+			AUTOMATION_TIME_SLOT_PERIOD,
 			delegator.clone(),
 			1_000_000_000,
 		));
@@ -1113,9 +1126,9 @@ fn schedule_max_execution_times_errors() {
 				ScheduleParam::Fixed {
 					execution_times: vec![
 						SCHEDULED_TIME,
-						SCHEDULED_TIME + 3600,
-						SCHEDULED_TIME + 7200,
-						SCHEDULED_TIME + 10800
+						SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+						SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2,
+						SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 3
 					]
 				},
 				Box::new(frame_system::Call::remark { remark: vec![2, 4, 5] }.into())
@@ -1140,7 +1153,7 @@ fn schedule_execution_times_removes_dupes() {
 				SCHEDULED_TIME,
 				SCHEDULED_TIME,
 				SCHEDULED_TIME,
-				SCHEDULED_TIME + 10800,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 3,
 			],
 			vec![2, 4],
 		);
@@ -1153,7 +1166,7 @@ fn schedule_execution_times_removes_dupes() {
 				let expected_task = TaskOf::<Test>::create_event_task::<Test>(
 					AccountId32::new(ALICE),
 					vec![49, 45, 48, 45, 52],
-					vec![SCHEDULED_TIME, SCHEDULED_TIME + 10800],
+					vec![SCHEDULED_TIME, SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 3],
 					vec![2, 4],
 					vec![],
 				)
@@ -1226,11 +1239,19 @@ fn schedule_time_slot_full_rolls_back() {
 		let call1: RuntimeCall = frame_system::Call::remark { remark: vec![2, 4, 5] }.into();
 		assert_ok!(fund_account_dynamic_dispatch(&AccountId32::new(ALICE), 1, call1.encode()));
 
-		let task_id1 = schedule_task(ALICE, vec![SCHEDULED_TIME + 7200], vec![2, 4, 5]);
+		let task_id1 = schedule_task(
+			ALICE,
+			vec![SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2],
+			vec![2, 4, 5],
+		);
 
 		let _call2: RuntimeCall = frame_system::Call::remark { remark: vec![2, 4] }.into();
 		assert_ok!(fund_account_dynamic_dispatch(&AccountId32::new(ALICE), 1, call1.encode()));
-		let task_id2 = schedule_task(ALICE, vec![SCHEDULED_TIME + 7200], vec![2, 4]);
+		let task_id2 = schedule_task(
+			ALICE,
+			vec![SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2],
+			vec![2, 4],
+		);
 
 		let call: RuntimeCall = frame_system::Call::remark { remark: vec![2] }.into();
 		assert_ok!(fund_account_dynamic_dispatch(&AccountId32::new(ALICE), 1, call.encode()));
@@ -1240,8 +1261,8 @@ fn schedule_time_slot_full_rolls_back() {
 				ScheduleParam::Fixed {
 					execution_times: vec![
 						SCHEDULED_TIME,
-						SCHEDULED_TIME + 3600,
-						SCHEDULED_TIME + 7200
+						SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+						SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2
 					]
 				},
 				Box::new(call)
@@ -1252,10 +1273,13 @@ fn schedule_time_slot_full_rolls_back() {
 		if AutomationTime::get_scheduled_tasks(SCHEDULED_TIME).is_some() {
 			panic!("Tasks scheduled for the time it should have been rolled back")
 		}
-		if AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + 3600).is_some() {
+		if AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD)
+			.is_some()
+		{
 			panic!("Tasks scheduled for the time it should have been rolled back")
 		}
-		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + 7200) {
+		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2)
+		{
 			None => {
 				panic!("A task should be scheduled")
 			},
@@ -1274,17 +1298,28 @@ fn taskid_changed_per_block() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		let task_id1 = schedule_task(
 			ALICE,
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600, SCHEDULED_TIME + 7200],
+			vec![
+				SCHEDULED_TIME,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2,
+			],
 			vec![2, 4, 5],
 		);
 
 		System::set_block_number(20);
 		let task_id2 = schedule_task(
 			ALICE,
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600, SCHEDULED_TIME + 7200],
+			vec![
+				SCHEDULED_TIME,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2,
+			],
 			vec![2, 4, 5],
 		);
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 14400, SCHEDULED_TIME - 14400));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 4,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 4,
+		));
 
 		assert_eq!(task_id1, FIRST_TASK_ID.to_vec());
 		assert_eq!(task_id2, vec![50, 48, 45, 48, 45, 54]);
@@ -1298,7 +1333,11 @@ fn taskid_adjusted_on_extrinsicid_on_same_block() {
 		let first_caller = AccountId32::new(ALICE);
 		let task_id1 = schedule_task(
 			ALICE,
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600, SCHEDULED_TIME + 7200],
+			vec![
+				SCHEDULED_TIME,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2,
+			],
 			vec![2, 4, 5],
 		);
 
@@ -1308,10 +1347,17 @@ fn taskid_adjusted_on_extrinsicid_on_same_block() {
 		let second_caller = AccountId32::new(BOB);
 		let task_id2 = schedule_task(
 			BOB,
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600, SCHEDULED_TIME + 7200],
+			vec![
+				SCHEDULED_TIME,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2,
+			],
 			vec![2, 4, 5],
 		);
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 14400, SCHEDULED_TIME - 14400));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 3,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 3,
+		));
 
 		assert_eq!(task_id1, FIRST_TASK_ID.to_vec());
 		assert_eq!(task_id2, vec![49, 45, 50, 51, 52, 45, 56]);
@@ -1338,7 +1384,11 @@ fn taskid_adjusted_on_eventindex_on_same_block_from_same_caller() {
 
 		let task_id1 = schedule_task(
 			ALICE,
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600, SCHEDULED_TIME + 7200],
+			vec![
+				SCHEDULED_TIME,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2,
+			],
 			vec![2, 4, 5],
 		);
 
@@ -1347,7 +1397,11 @@ fn taskid_adjusted_on_eventindex_on_same_block_from_same_caller() {
 
 		let task_id2 = schedule_task(
 			ALICE,
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600, SCHEDULED_TIME + 7200],
+			vec![
+				SCHEDULED_TIME,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2,
+			],
 			vec![2, 4, 5],
 		);
 
@@ -1377,16 +1431,27 @@ fn taskid_on_same_extrinsid_have_unique_event_index() {
 		let owner = AccountId32::new(ALICE);
 		let task_id1 = schedule_task(
 			ALICE,
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600, SCHEDULED_TIME + 7200],
+			vec![
+				SCHEDULED_TIME,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2,
+			],
 			vec![2, 4, 5],
 		);
 
 		let task_id2 = schedule_task(
 			ALICE,
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600, SCHEDULED_TIME + 7200],
+			vec![
+				SCHEDULED_TIME,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2,
+			],
 			vec![2, 4, 5],
 		);
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 14400, SCHEDULED_TIME - 14400));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 3,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 3,
+		));
 
 		assert_eq!(task_id1, FIRST_TASK_ID.to_vec());
 		assert_eq!(task_id2, SECOND_TASK_ID.to_vec());
@@ -1407,7 +1472,10 @@ fn cancel_works_for_fixed_scheduled() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		let task_id1 = schedule_task(ALICE, vec![SCHEDULED_TIME], vec![2, 4, 5]);
 		let task_id2 = schedule_task(ALICE, vec![SCHEDULED_TIME], vec![2, 4]);
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 14400, SCHEDULED_TIME - 14400));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 4,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 4,
+		));
 		System::reset_events();
 
 		assert_ok!(AutomationTime::cancel_task(
@@ -1447,10 +1515,17 @@ fn cancel_works_for_multiple_executions_scheduled() {
 		let owner = AccountId32::new(ALICE);
 		let task_id1 = schedule_task(
 			ALICE,
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600, SCHEDULED_TIME + 7200],
+			vec![
+				SCHEDULED_TIME,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2,
+			],
 			vec![2, 4, 5],
 		);
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 14400, SCHEDULED_TIME - 14400));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 3,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 3,
+		));
 		System::reset_events();
 
 		assert_ok!(AutomationTime::cancel_task(
@@ -1462,10 +1537,14 @@ fn cancel_works_for_multiple_executions_scheduled() {
 		if AutomationTime::get_scheduled_tasks(SCHEDULED_TIME).is_some() {
 			panic!("Tasks scheduled for the time it should have been deleted")
 		}
-		if AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + 3600).is_some() {
+		if AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD)
+			.is_some()
+		{
 			panic!("Tasks scheduled for the time it should have been deleted")
 		}
-		if AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + 7200).is_some() {
+		if AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2)
+			.is_some()
+		{
 			panic!("Tasks scheduled for the time it should have been deleted")
 		}
 		assert_eq!(
@@ -1482,10 +1561,19 @@ fn cancel_works_for_multiple_executions_scheduled() {
 #[test]
 fn cancel_works_for_recurring_scheduled() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
-		let task_id1 = schedule_recurring_task(ALICE, SCHEDULED_TIME, 3600, vec![2, 4, 5]);
-		let task_id2 = schedule_recurring_task(ALICE, SCHEDULED_TIME, 3600, vec![2, 4]);
+		let task_id1 = schedule_recurring_task(
+			ALICE,
+			SCHEDULED_TIME,
+			AUTOMATION_TIME_SLOT_PERIOD,
+			vec![2, 4, 5],
+		);
+		let task_id2 =
+			schedule_recurring_task(ALICE, SCHEDULED_TIME, AUTOMATION_TIME_SLOT_PERIOD, vec![2, 4]);
 
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 14400, SCHEDULED_TIME - 14400));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 4,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 4,
+		));
 		System::reset_events();
 
 		assert_ok!(AutomationTime::cancel_task(
@@ -1526,11 +1614,14 @@ fn cancel_works_for_an_executed_task() {
 		let call: RuntimeCall = frame_system::Call::remark_with_event { remark: vec![50] }.into();
 		let task_id1 = schedule_dynamic_dispatch_task(
 			ALICE,
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600],
+			vec![SCHEDULED_TIME, SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD],
 			call.clone(),
 		);
 		Timestamp::set_timestamp(SCHEDULED_TIME * 1_000);
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 3600, SCHEDULED_TIME - 3600));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD,
+		));
 		System::reset_events();
 
 		match AutomationTime::get_account_task(owner.clone(), task_id1.clone()) {
@@ -1551,7 +1642,7 @@ fn cancel_works_for_an_executed_task() {
 				assert_eq!(task_ids[0].1, task_id1);
 			},
 		}
-		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + 3600) {
+		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD) {
 			None => {
 				panic!("A task should be scheduled")
 			},
@@ -1596,7 +1687,7 @@ fn cancel_works_for_an_executed_task() {
 		}
 
 		assert_eq!(AutomationTime::get_scheduled_tasks(SCHEDULED_TIME), None);
-		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + 3600) {
+		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD) {
 			None => {
 				panic!("A task should be scheduled")
 			},
@@ -1612,7 +1703,10 @@ fn cancel_works_for_an_executed_task() {
 		));
 
 		assert_eq!(AutomationTime::get_scheduled_tasks(SCHEDULED_TIME), None);
-		assert_eq!(AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + 3600), None);
+		assert_eq!(
+			AutomationTime::get_scheduled_tasks(SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD),
+			None
+		);
 
 		assert_eq!(AutomationTime::get_account_task(owner.clone(), task_id1.clone()), None);
 		assert_eq!(
@@ -1725,10 +1819,17 @@ fn cancel_task_fail_non_owner() {
 		let owner = AccountId32::new(ALICE);
 		let task_id1 = schedule_task(
 			ALICE,
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600, SCHEDULED_TIME + 7200],
+			vec![
+				SCHEDULED_TIME,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+				SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2,
+			],
 			vec![2, 4, 5],
 		);
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 14400, SCHEDULED_TIME - 14400));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 3,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 3,
+		));
 
 		System::reset_events();
 
@@ -1751,7 +1852,10 @@ fn cancel_task_fail_non_owner() {
 fn force_cancel_task_works() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		let task_id = schedule_task(ALICE, vec![SCHEDULED_TIME], vec![2, 4, 5]);
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 14400, SCHEDULED_TIME - 14400));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 4,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 4,
+		));
 		System::reset_events();
 
 		assert_ok!(AutomationTime::force_cancel_task(
@@ -1908,19 +2012,22 @@ fn trigger_tasks_updates_queues() {
 		let missed_task_id = add_task_to_task_queue(
 			ALICE,
 			vec![40],
-			vec![SCHEDULED_TIME - 3600],
+			vec![SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD],
 			create_dynamic_dispatch_remark_action(vec![40]),
 			vec![],
 		);
 		let missed_task = MissedTaskV2Of::<Test>::new(
 			AccountId32::new(ALICE),
 			missed_task_id,
-			SCHEDULED_TIME - 3600,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD,
 		);
 		assert_eq!(AutomationTime::get_missed_queue().len(), 0);
 		let scheduled_task_id = schedule_task(ALICE, vec![SCHEDULED_TIME], vec![50]);
 		Timestamp::set_timestamp(SCHEDULED_TIME * 1_000);
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 3600, SCHEDULED_TIME - 3600));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD,
+		));
 		System::reset_events();
 
 		AutomationTime::trigger_tasks(Weight::from_ref_time(50_000));
@@ -1956,11 +2063,12 @@ fn trigger_tasks_handles_missed_slots() {
 
 		assert_eq!(AutomationTime::get_missed_queue().len(), 0);
 
-		let missed_task_id = schedule_task(ALICE, vec![SCHEDULED_TIME - 3600], vec![50]);
+		let missed_task_id =
+			schedule_task(ALICE, vec![SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD], vec![50]);
 		let missed_task = MissedTaskV2Of::<Test>::new(
 			AccountId32::new(ALICE),
 			missed_task_id,
-			SCHEDULED_TIME - 3600,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD,
 		);
 
 		let remark_message = vec![50];
@@ -1971,7 +2079,10 @@ fn trigger_tasks_handles_missed_slots() {
 		let scheduled_task_id = schedule_task(ALICE, vec![SCHEDULED_TIME], vec![50]);
 
 		Timestamp::set_timestamp(SCHEDULED_TIME * 1_000);
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 7200, SCHEDULED_TIME - 7200));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 2,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 2,
+		));
 		System::reset_events();
 
 		// Give this enough weight limit to run and process miss queue and generate miss event
@@ -2044,12 +2155,17 @@ fn trigger_tasks_limits_missed_slots() {
 		assert_eq!(AutomationTime::get_missed_queue().len(), 0);
 
 		Timestamp::set_timestamp((SCHEDULED_TIME - 25200) * 1_000);
-		let missing_task_id1 = schedule_task(ALICE, vec![SCHEDULED_TIME - 3600], vec![50]);
+		let missing_task_id1 =
+			schedule_task(ALICE, vec![SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD], vec![50]);
 
-		let missing_task_id2 = schedule_task(ALICE, vec![SCHEDULED_TIME - 7200], vec![50]);
-		let missing_task_id3 = schedule_task(ALICE, vec![SCHEDULED_TIME - 10800], vec![50]);
-		let missing_task_id4 = schedule_task(ALICE, vec![SCHEDULED_TIME - 14400], vec![50]);
-		let missing_task_id5 = schedule_task(ALICE, vec![SCHEDULED_TIME - 18000], vec![50]);
+		let missing_task_id2 =
+			schedule_task(ALICE, vec![SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 2], vec![50]);
+		let missing_task_id3 =
+			schedule_task(ALICE, vec![SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 3], vec![50]);
+		let missing_task_id4 =
+			schedule_task(ALICE, vec![SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 4], vec![50]);
+		let missing_task_id5 =
+			schedule_task(ALICE, vec![SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 5], vec![50]);
 
 		let remark_message = vec![50];
 		let call: <Test as frame_system::Config>::RuntimeCall =
@@ -2057,7 +2173,10 @@ fn trigger_tasks_limits_missed_slots() {
 		let task_id = schedule_dynamic_dispatch_task(ALICE, vec![SCHEDULED_TIME], call.clone());
 
 		Timestamp::set_timestamp(SCHEDULED_TIME * 1_000);
-		LastTimeSlot::<Test>::put((SCHEDULED_TIME - 25200, SCHEDULED_TIME - 25200));
+		LastTimeSlot::<Test>::put((
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 7,
+			SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 7,
+		));
 		System::reset_events();
 
 		AutomationTime::trigger_tasks(Weight::from_ref_time(7_769_423 + 200_000));
@@ -2070,7 +2189,7 @@ fn trigger_tasks_limits_missed_slots() {
 			AutomationTime::get_last_slot()
 		{
 			assert_eq!(updated_last_time_slot, SCHEDULED_TIME);
-			assert_eq!(updated_last_missed_slot, SCHEDULED_TIME - 10800);
+			assert_eq!(updated_last_missed_slot, SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 3);
 
 			let mut condition: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
 			condition.insert("type".as_bytes().to_vec(), "time".as_bytes().to_vec());
@@ -2103,7 +2222,7 @@ fn trigger_tasks_limits_missed_slots() {
 					RuntimeEvent::AutomationTime(crate::Event::TaskMissed {
 						who: owner.clone(),
 						task_id: missing_task_id0.clone(),
-						execution_time: SCHEDULED_TIME - 25200,
+						execution_time: SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 7,
 					}),
 					RuntimeEvent::AutomationTime(crate::Event::TaskCompleted {
 						who: owner.clone(),
@@ -2113,7 +2232,7 @@ fn trigger_tasks_limits_missed_slots() {
 					RuntimeEvent::AutomationTime(crate::Event::TaskMissed {
 						who: owner.clone(),
 						task_id: missing_task_id5.clone(),
-						execution_time: SCHEDULED_TIME - 18000,
+						execution_time: SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 5,
 					}),
 					RuntimeEvent::AutomationTime(crate::Event::TaskCompleted {
 						who: owner.clone(),
@@ -2123,7 +2242,7 @@ fn trigger_tasks_limits_missed_slots() {
 					RuntimeEvent::AutomationTime(crate::Event::TaskMissed {
 						who: owner.clone(),
 						task_id: missing_task_id4.clone(),
-						execution_time: SCHEDULED_TIME - 14400,
+						execution_time: SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 4,
 					}),
 					RuntimeEvent::AutomationTime(crate::Event::TaskCompleted {
 						who: owner.clone(),
@@ -2133,7 +2252,7 @@ fn trigger_tasks_limits_missed_slots() {
 					RuntimeEvent::AutomationTime(crate::Event::TaskMissed {
 						who: owner.clone(),
 						task_id: missing_task_id3.clone(),
-						execution_time: SCHEDULED_TIME - 10800,
+						execution_time: SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 3,
 					}),
 					RuntimeEvent::AutomationTime(crate::Event::TaskCompleted {
 						who: owner,
@@ -2145,7 +2264,8 @@ fn trigger_tasks_limits_missed_slots() {
 			panic!("trigger_tasks_limits_missed_slots test did not have LastTimeSlot updated")
 		}
 
-		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME - 7200) {
+		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD * 2)
+		{
 			None => {
 				panic!("A task should be scheduled")
 			},
@@ -2155,7 +2275,7 @@ fn trigger_tasks_limits_missed_slots() {
 			},
 		}
 
-		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME - 3600) {
+		match AutomationTime::get_scheduled_tasks(SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD) {
 			None => {
 				panic!("A task should be scheduled")
 			},
@@ -2383,14 +2503,14 @@ fn missed_tasks_updates_executions_left() {
 		let task_id1 = add_task_to_missed_queue(
 			ALICE,
 			vec![40],
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600],
+			vec![SCHEDULED_TIME, SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD],
 			create_dynamic_dispatch_remark_action(vec![40]),
 			vec![],
 		);
 		let task_id2 = add_task_to_missed_queue(
 			ALICE,
 			vec![50],
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600],
+			vec![SCHEDULED_TIME, SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD],
 			create_dynamic_dispatch_remark_action(vec![40]),
 			vec![],
 		);
@@ -2459,7 +2579,7 @@ fn missed_tasks_removes_completed_tasks() {
 		let task_id01 = add_task_to_missed_queue(
 			ALICE,
 			vec![40],
-			vec![SCHEDULED_TIME, SCHEDULED_TIME - 3600],
+			vec![SCHEDULED_TIME, SCHEDULED_TIME - AUTOMATION_TIME_SLOT_PERIOD],
 			create_dynamic_dispatch_remark_action(message_one.clone()),
 			vec![],
 		);
@@ -2595,7 +2715,7 @@ fn trigger_tasks_completes_auto_compound_delegated_stake_task() {
 			DELEGATOR_ACCOUNT,
 			task_id.clone(),
 			SCHEDULED_TIME,
-			3600,
+			AUTOMATION_TIME_SLOT_PERIOD,
 			action.clone(),
 			vec![],
 		);
@@ -2665,7 +2785,7 @@ fn auto_compound_delegated_stake_enough_balance_has_delegation() {
 		let before_balance = Balances::free_balance(delegator.clone());
 		// Minimum balance is half of the user's wallet balance
 		let account_minimum = before_balance / 2;
-		let frequency = 3_600;
+		let frequency = AUTOMATION_TIME_SLOT_PERIOD;
 
 		let task_id = add_recurring_task_to_task_queue(
 			DELEGATOR_ACCOUNT,
@@ -2743,7 +2863,7 @@ fn auto_compound_delegated_stake_not_enough_balance_has_delegation() {
 		let before_balance = Balances::free_balance(delegator.clone());
 		// Minimum balance is twice of the user's wallet balance
 		let account_minimum = before_balance * 2;
-		let frequency = 3_600;
+		let frequency = AUTOMATION_TIME_SLOT_PERIOD;
 
 		let task_id = add_recurring_task_to_task_queue(
 			DELEGATOR_ACCOUNT,
@@ -2806,7 +2926,7 @@ fn auto_compound_delegated_stake_enough_balance_no_delegator() {
 		let before_balance = Balances::free_balance(delegator.clone());
 		// Minimum balance is half of the user's wallet balance
 		let account_minimum = before_balance / 2;
-		let frequency = 3_600;
+		let frequency = AUTOMATION_TIME_SLOT_PERIOD;
 
 		let task_id = add_recurring_task_to_task_queue(
 			ALICE,
@@ -2880,7 +3000,7 @@ fn auto_compound_delegated_stake_enough_balance_no_delegation() {
 		let before_balance = Balances::free_balance(delegator.clone());
 		// Minimum balance is half of the user's wallet balance
 		let account_minimum = before_balance / 2;
-		let frequency = 3_600;
+		let frequency = AUTOMATION_TIME_SLOT_PERIOD;
 
 		let task_id = add_recurring_task_to_task_queue(
 			DELEGATOR_ACCOUNT,
@@ -2955,7 +3075,7 @@ fn auto_compound_delegated_stake_not_enough_balance_no_delegation() {
 		let before_balance = Balances::free_balance(delegator.clone());
 		// Minimum balance is twice of the user's wallet balance
 		let account_minimum = before_balance * 2;
-		let frequency = 3_600;
+		let frequency = AUTOMATION_TIME_SLOT_PERIOD;
 
 		let task_id = add_recurring_task_to_task_queue(
 			DELEGATOR_ACCOUNT,
@@ -3022,7 +3142,7 @@ fn trigger_tasks_updates_executions_left() {
 		let task_id01 = add_task_to_task_queue(
 			ALICE,
 			vec![40],
-			vec![SCHEDULED_TIME, SCHEDULED_TIME + 3600],
+			vec![SCHEDULED_TIME, SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD],
 			create_dynamic_dispatch_remark_action(message_one.clone()),
 			vec![],
 		);
@@ -3217,7 +3337,7 @@ fn on_init_runs_tasks() {
 		assert_eq!(AutomationTime::get_task_queue().len(), 1);
 		assert_eq!(AutomationTime::get_missed_queue().len(), 0);
 
-		Timestamp::set_timestamp(START_BLOCK_TIME + (3600 * 1_000));
+		Timestamp::set_timestamp(START_BLOCK_TIME + (AUTOMATION_TIME_SLOT_PERIOD * 1_000));
 		AutomationTime::on_initialize(2);
 		assert_eq!(
 			events(),
@@ -3245,7 +3365,10 @@ fn on_init_runs_tasks() {
 #[test]
 fn on_init_check_task_queue() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
-		LastTimeSlot::<Test>::put((LAST_BLOCK_TIME, LAST_BLOCK_TIME - 7200));
+		LastTimeSlot::<Test>::put((
+			LAST_BLOCK_TIME,
+			LAST_BLOCK_TIME - AUTOMATION_TIME_SLOT_PERIOD * 2,
+		));
 		let mut tasks = vec![];
 
 		for i in 0..5 {
@@ -3357,7 +3480,7 @@ fn on_init_check_task_queue() {
 		assert_eq!(AutomationTime::get_task_queue().len(), 1);
 		assert_eq!(AutomationTime::get_missed_queue().len(), 0);
 
-		Timestamp::set_timestamp(START_BLOCK_TIME + (3600 * 1000));
+		Timestamp::set_timestamp(START_BLOCK_TIME + (AUTOMATION_TIME_SLOT_PERIOD * 1000));
 		AutomationTime::on_initialize(3);
 		assert_eq!(
 			events(),
@@ -3411,7 +3534,7 @@ fn on_init_shutdown() {
 
 		AutomationTime::on_initialize(1);
 		assert_eq!(events(), []);
-		Timestamp::set_timestamp(START_BLOCK_TIME + (3600 * 1_000));
+		Timestamp::set_timestamp(START_BLOCK_TIME + (AUTOMATION_TIME_SLOT_PERIOD * 1_000));
 		AutomationTime::on_initialize(2);
 		assert_eq!(events(), [],);
 		assert_ne!(AutomationTime::get_account_task(owner.clone(), task_id1), None);

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -1011,11 +1011,11 @@ fn schedule_auto_compound_with_bad_frequency_or_execution_time() {
 // when schedule auto compound task, if the schedule time falls too far in the
 // future, return TimeTooFarOut error
 #[test]
-fn schedule_auto_compound_with_high_frequency() {
+fn schedule_auto_compound_with_time_too_far_out() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		for (execution_time, frequency) in vec![
-			(SCHEDULED_TIME, <Test as Config>::MaxScheduleSeconds::get() + SLOT_SIZE_SECONDS),
-			(SCHEDULED_TIME + 7 * 24 * SLOT_SIZE_SECONDS, SLOT_SIZE_SECONDS),
+			(SCHEDULED_TIME, MAX_SCHEDULE_SECONDS + SLOT_SIZE_SECONDS),
+			(SCHEDULED_TIME + MAX_SCHEDULE_SECONDS + SLOT_SIZE_SECONDS, SLOT_SIZE_SECONDS),
 		]
 		.iter()
 		{
@@ -1336,8 +1336,8 @@ fn taskid_adjusted_on_extrinsicid_on_same_block() {
 			vec![2, 4, 5],
 		);
 		LastTimeSlot::<Test>::put((
-			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 3,
-			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 3,
+			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 4,
+			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 4,
 		));
 
 		assert_eq!(task_id1, FIRST_TASK_ID.to_vec());
@@ -1430,8 +1430,8 @@ fn taskid_on_same_extrinsid_have_unique_event_index() {
 			vec![2, 4, 5],
 		);
 		LastTimeSlot::<Test>::put((
-			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 3,
-			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 3,
+			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 4,
+			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 4,
 		));
 
 		assert_eq!(task_id1, FIRST_TASK_ID.to_vec());
@@ -1504,8 +1504,8 @@ fn cancel_works_for_multiple_executions_scheduled() {
 			vec![2, 4, 5],
 		);
 		LastTimeSlot::<Test>::put((
-			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 3,
-			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 3,
+			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 4,
+			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 4,
 		));
 		System::reset_events();
 
@@ -1797,8 +1797,8 @@ fn cancel_task_fail_non_owner() {
 			vec![2, 4, 5],
 		);
 		LastTimeSlot::<Test>::put((
-			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 3,
-			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 3,
+			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 4,
+			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 4,
 		));
 
 		System::reset_events();

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -456,9 +456,9 @@ mod tests {
 		#[test]
 		fn sets_executions_left() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				let t1 = SCHEDULED_TIME + 3600;
-				let t2 = SCHEDULED_TIME + 3600 * 2;
-				let t3 = SCHEDULED_TIME + 3600 * 3;
+				let t1 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD;
+				let t2 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2;
+				let t3 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 3;
 				let s = ScheduleParam::Fixed { execution_times: vec![t1, t2, t3] }
 					.validated_into::<Test>()
 					.expect("valid");
@@ -473,7 +473,7 @@ mod tests {
 		#[test]
 		fn validates_fixed_schedule() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				let t1 = SCHEDULED_TIME + 1800;
+				let t1 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD / 2;
 				let s = ScheduleParam::Fixed { execution_times: vec![t1] }.validated_into::<Test>();
 				assert_err!(s, Error::<Test>::InvalidTime);
 			})
@@ -484,7 +484,7 @@ mod tests {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
 				let s = ScheduleParam::Recurring {
 					next_execution_time: SCHEDULED_TIME,
-					frequency: 3600,
+					frequency: AUTOMATION_TIME_SLOT_PERIOD,
 				}
 				.validated_into::<Test>()
 				.expect("valid");
@@ -496,7 +496,7 @@ mod tests {
 
 				let s = ScheduleParam::Recurring {
 					next_execution_time: SCHEDULED_TIME,
-					frequency: 3601,
+					frequency: AUTOMATION_TIME_SLOT_PERIOD + 1,
 				}
 				.validated_into::<Test>();
 				assert_err!(s, Error::<Test>::InvalidTime);
@@ -506,16 +506,16 @@ mod tests {
 		#[test]
 		fn counts_executions() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				let t1 = SCHEDULED_TIME + 3600;
-				let t2 = SCHEDULED_TIME + 3600 * 2;
-				let t3 = SCHEDULED_TIME + 3600 * 3;
+				let t1 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD;
+				let t2 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2;
+				let t3 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 3;
 
 				let s = ScheduleParam::Fixed { execution_times: vec![t1, t2, t3] };
 				assert_eq!(s.number_of_executions(), 3);
 
 				let s = ScheduleParam::Recurring {
 					next_execution_time: SCHEDULED_TIME,
-					frequency: 3600,
+					frequency: AUTOMATION_TIME_SLOT_PERIOD,
 				};
 				assert_eq!(s.number_of_executions(), 1);
 			})
@@ -528,9 +528,9 @@ mod tests {
 		#[test]
 		fn new_fixed_schedule_sets_executions_left() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				let t1 = SCHEDULED_TIME + 3600;
-				let t2 = SCHEDULED_TIME + 3600 * 2;
-				let t3 = SCHEDULED_TIME + 3600 * 3;
+				let t1 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD;
+				let t2 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2;
+				let t3 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 3;
 				let s = Schedule::new_fixed_schedule::<Test>(vec![t1, t2, t3]).unwrap();
 				if let Schedule::Fixed { executions_left, .. } = s {
 					assert_eq!(executions_left, 3);
@@ -553,9 +553,9 @@ mod tests {
 		#[test]
 		fn new_fixed_schedule_cleans_execution_times() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				let t1 = SCHEDULED_TIME + 3600;
-				let t2 = SCHEDULED_TIME + 3600 * 2;
-				let t3 = SCHEDULED_TIME + 3600 * 3;
+				let t1 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD;
+				let t2 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2;
+				let t3 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 3;
 				let s = Schedule::new_fixed_schedule::<Test>(vec![t1, t3, t2, t3, t3]);
 				if let Schedule::Fixed { execution_times, .. } = s.unwrap() {
 					assert_eq!(execution_times, vec![t1, t2, t3]);
@@ -568,12 +568,15 @@ mod tests {
 		#[test]
 		fn checks_for_fixed_schedule_validity() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				assert_ok!(Schedule::new_fixed_schedule::<Test>(vec![SCHEDULED_TIME + 3600]));
+				assert_ok!(Schedule::new_fixed_schedule::<Test>(vec![
+					SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD
+				]));
 				// Execution time does not end in whole hour
 				assert_err!(
 					Schedule::new_fixed_schedule::<Test>(vec![
-						SCHEDULED_TIME + 3600,
-						SCHEDULED_TIME + 3650
+						SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
+						SCHEDULED_TIME +
+							AUTOMATION_TIME_SLOT_PERIOD + AUTOMATION_TIME_SLOT_PERIOD / 2
 					]),
 					Error::<Test>::InvalidTime
 				);
@@ -590,33 +593,46 @@ mod tests {
 			let start_time = 1_663_225_200;
 			new_test_ext(start_time * 1_000).execute_with(|| {
 				assert_ok!(Schedule::Recurring {
-					next_execution_time: start_time + 3600,
-					frequency: 3600
+					next_execution_time: start_time + AUTOMATION_TIME_SLOT_PERIOD,
+					frequency: AUTOMATION_TIME_SLOT_PERIOD
 				}
 				.valid::<Test>());
 				// Next execution time not at hour granuality
 				assert_err!(
-					Schedule::Recurring { next_execution_time: start_time + 3650, frequency: 3600 }
-						.valid::<Test>(),
+					Schedule::Recurring {
+						next_execution_time: start_time +
+							AUTOMATION_TIME_SLOT_PERIOD +
+							AUTOMATION_TIME_SLOT_PERIOD / 2,
+						frequency: AUTOMATION_TIME_SLOT_PERIOD
+					}
+					.valid::<Test>(),
 					Error::<Test>::InvalidTime
 				);
 				// Frequency not at hour granularity
 				assert_err!(
-					Schedule::Recurring { next_execution_time: start_time + 3650, frequency: 3650 }
-						.valid::<Test>(),
+					Schedule::Recurring {
+						next_execution_time: start_time +
+							AUTOMATION_TIME_SLOT_PERIOD +
+							AUTOMATION_TIME_SLOT_PERIOD / 2,
+						frequency: AUTOMATION_TIME_SLOT_PERIOD + AUTOMATION_TIME_SLOT_PERIOD / 2
+					}
+					.valid::<Test>(),
 					Error::<Test>::InvalidTime
 				);
 				// Frequency of 0
 				assert_err!(
-					Schedule::Recurring { next_execution_time: start_time + 3600, frequency: 0 }
-						.valid::<Test>(),
+					Schedule::Recurring {
+						next_execution_time: start_time + AUTOMATION_TIME_SLOT_PERIOD,
+						frequency: 0
+					}
+					.valid::<Test>(),
 					Error::<Test>::InvalidTime
 				);
 				// Frequency too far out
 				assert_err!(
 					Schedule::Recurring {
-						next_execution_time: start_time + 3600,
-						frequency: start_time + 3600
+						next_execution_time: start_time + AUTOMATION_TIME_SLOT_PERIOD,
+						frequency: start_time + AUTOMATION_TIME_SLOT_PERIOD
 					}
 					.valid::<Test>(),
 					Error::<Test>::TimeTooFarOut

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -349,7 +349,7 @@ mod tests {
 	use super::*;
 	use crate::{
 		mock::*,
-		tests::{SCHEDULED_TIME, START_BLOCK_TIME},
+		tests::{SCHEDULED_TIME, SLOT_SIZE_SECONDS, START_BLOCK_TIME},
 	};
 	use frame_support::{assert_err, assert_ok};
 
@@ -456,9 +456,9 @@ mod tests {
 		#[test]
 		fn sets_executions_left() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				let t1 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD;
-				let t2 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2;
-				let t3 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 3;
+				let t1 = SCHEDULED_TIME + SLOT_SIZE_SECONDS;
+				let t2 = SCHEDULED_TIME + SLOT_SIZE_SECONDS * 2;
+				let t3 = SCHEDULED_TIME + SLOT_SIZE_SECONDS * 3;
 				let s = ScheduleParam::Fixed { execution_times: vec![t1, t2, t3] }
 					.validated_into::<Test>()
 					.expect("valid");
@@ -473,7 +473,7 @@ mod tests {
 		#[test]
 		fn validates_fixed_schedule() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				let t1 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD / 2;
+				let t1 = SCHEDULED_TIME + SLOT_SIZE_SECONDS / 2;
 				let s = ScheduleParam::Fixed { execution_times: vec![t1] }.validated_into::<Test>();
 				assert_err!(s, Error::<Test>::InvalidTime);
 			})
@@ -484,7 +484,7 @@ mod tests {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
 				let s = ScheduleParam::Recurring {
 					next_execution_time: SCHEDULED_TIME,
-					frequency: AUTOMATION_TIME_SLOT_PERIOD,
+					frequency: SLOT_SIZE_SECONDS,
 				}
 				.validated_into::<Test>()
 				.expect("valid");
@@ -496,7 +496,7 @@ mod tests {
 
 				let s = ScheduleParam::Recurring {
 					next_execution_time: SCHEDULED_TIME,
-					frequency: AUTOMATION_TIME_SLOT_PERIOD + 1,
+					frequency: SLOT_SIZE_SECONDS + 1,
 				}
 				.validated_into::<Test>();
 				assert_err!(s, Error::<Test>::InvalidTime);
@@ -506,16 +506,16 @@ mod tests {
 		#[test]
 		fn counts_executions() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				let t1 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD;
-				let t2 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2;
-				let t3 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 3;
+				let t1 = SCHEDULED_TIME + SLOT_SIZE_SECONDS;
+				let t2 = SCHEDULED_TIME + SLOT_SIZE_SECONDS * 2;
+				let t3 = SCHEDULED_TIME + SLOT_SIZE_SECONDS * 3;
 
 				let s = ScheduleParam::Fixed { execution_times: vec![t1, t2, t3] };
 				assert_eq!(s.number_of_executions(), 3);
 
 				let s = ScheduleParam::Recurring {
 					next_execution_time: SCHEDULED_TIME,
-					frequency: AUTOMATION_TIME_SLOT_PERIOD,
+					frequency: SLOT_SIZE_SECONDS,
 				};
 				assert_eq!(s.number_of_executions(), 1);
 			})
@@ -528,9 +528,9 @@ mod tests {
 		#[test]
 		fn new_fixed_schedule_sets_executions_left() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				let t1 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD;
-				let t2 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2;
-				let t3 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 3;
+				let t1 = SCHEDULED_TIME + SLOT_SIZE_SECONDS;
+				let t2 = SCHEDULED_TIME + SLOT_SIZE_SECONDS * 2;
+				let t3 = SCHEDULED_TIME + SLOT_SIZE_SECONDS * 3;
 				let s = Schedule::new_fixed_schedule::<Test>(vec![t1, t2, t3]).unwrap();
 				if let Schedule::Fixed { executions_left, .. } = s {
 					assert_eq!(executions_left, 3);
@@ -553,9 +553,9 @@ mod tests {
 		#[test]
 		fn new_fixed_schedule_cleans_execution_times() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
-				let t1 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD;
-				let t2 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 2;
-				let t3 = SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD * 3;
+				let t1 = SCHEDULED_TIME + SLOT_SIZE_SECONDS;
+				let t2 = SCHEDULED_TIME + SLOT_SIZE_SECONDS * 2;
+				let t3 = SCHEDULED_TIME + SLOT_SIZE_SECONDS * 3;
 				let s = Schedule::new_fixed_schedule::<Test>(vec![t1, t3, t2, t3, t3]);
 				if let Schedule::Fixed { execution_times, .. } = s.unwrap() {
 					assert_eq!(execution_times, vec![t1, t2, t3]);
@@ -569,14 +569,13 @@ mod tests {
 		fn checks_for_fixed_schedule_validity() {
 			new_test_ext(START_BLOCK_TIME).execute_with(|| {
 				assert_ok!(Schedule::new_fixed_schedule::<Test>(vec![
-					SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD
+					SCHEDULED_TIME + SLOT_SIZE_SECONDS
 				]));
 				// Execution time does not end in whole hour
 				assert_err!(
 					Schedule::new_fixed_schedule::<Test>(vec![
-						SCHEDULED_TIME + AUTOMATION_TIME_SLOT_PERIOD,
-						SCHEDULED_TIME +
-							AUTOMATION_TIME_SLOT_PERIOD + AUTOMATION_TIME_SLOT_PERIOD / 2
+						SCHEDULED_TIME + SLOT_SIZE_SECONDS,
+						SCHEDULED_TIME + SLOT_SIZE_SECONDS + SLOT_SIZE_SECONDS / 2
 					]),
 					Error::<Test>::InvalidTime
 				);
@@ -593,17 +592,15 @@ mod tests {
 			let start_time = 1_663_225_200;
 			new_test_ext(start_time * 1_000).execute_with(|| {
 				assert_ok!(Schedule::Recurring {
-					next_execution_time: start_time + AUTOMATION_TIME_SLOT_PERIOD,
-					frequency: AUTOMATION_TIME_SLOT_PERIOD
+					next_execution_time: start_time + SLOT_SIZE_SECONDS,
+					frequency: SLOT_SIZE_SECONDS
 				}
 				.valid::<Test>());
 				// Next execution time not at hour granuality
 				assert_err!(
 					Schedule::Recurring {
-						next_execution_time: start_time +
-							AUTOMATION_TIME_SLOT_PERIOD +
-							AUTOMATION_TIME_SLOT_PERIOD / 2,
-						frequency: AUTOMATION_TIME_SLOT_PERIOD
+						next_execution_time: start_time + SLOT_SIZE_SECONDS + SLOT_SIZE_SECONDS / 2,
+						frequency: SLOT_SIZE_SECONDS
 					}
 					.valid::<Test>(),
 					Error::<Test>::InvalidTime
@@ -611,10 +608,8 @@ mod tests {
 				// Frequency not at hour granularity
 				assert_err!(
 					Schedule::Recurring {
-						next_execution_time: start_time +
-							AUTOMATION_TIME_SLOT_PERIOD +
-							AUTOMATION_TIME_SLOT_PERIOD / 2,
-						frequency: AUTOMATION_TIME_SLOT_PERIOD + AUTOMATION_TIME_SLOT_PERIOD / 2
+						next_execution_time: start_time + SLOT_SIZE_SECONDS + SLOT_SIZE_SECONDS / 2,
+						frequency: SLOT_SIZE_SECONDS + SLOT_SIZE_SECONDS / 2
 					}
 					.valid::<Test>(),
 					Error::<Test>::InvalidTime
@@ -622,7 +617,7 @@ mod tests {
 				// Frequency of 0
 				assert_err!(
 					Schedule::Recurring {
-						next_execution_time: start_time + AUTOMATION_TIME_SLOT_PERIOD,
+						next_execution_time: start_time + SLOT_SIZE_SECONDS,
 						frequency: 0
 					}
 					.valid::<Test>(),
@@ -631,8 +626,8 @@ mod tests {
 				// Frequency too far out
 				assert_err!(
 					Schedule::Recurring {
-						next_execution_time: start_time + AUTOMATION_TIME_SLOT_PERIOD,
-						frequency: start_time + AUTOMATION_TIME_SLOT_PERIOD
+						next_execution_time: start_time + SLOT_SIZE_SECONDS,
+						frequency: start_time + SLOT_SIZE_SECONDS
 					}
 					.valid::<Test>(),
 					Error::<Test>::TimeTooFarOut

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -51,7 +51,7 @@ use frame_support::{
 	dispatch::DispatchClass,
 	ensure, parameter_types,
 	traits::{
-		ConstU128, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
+		ConstU128, ConstU64, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
 		EnsureOriginWithArg, InstanceFilter, PrivilegeCmp,
 	},
 	weights::{
@@ -891,6 +891,7 @@ impl pallet_automation_time::Config for Runtime {
 	// Roughly .125% of parachain block weight per hour
 	// ≈ 500_000_000_000 (MaxBlockWeight) * 300 (Blocks/Hour) * .00125
 	type MaxWeightPerSlot = ConstU128<150_000_000_000>;
+	type SlotPeriod = ConstU64<600>;
 	type UpdateQueueRatio = UpdateQueueRatio;
 	type WeightInfo = pallet_automation_time::weights::SubstrateWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -835,7 +835,8 @@ impl pallet_democracy::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MaxScheduleSeconds: u64 = 7 * 24 * 60 * 60;
+	pub const MaxScheduleSeconds: u64 = 7 * 24 * 60 * 60;	// 7 days in seconds
+	pub const SlotSizeSeconds: u64 = 600; // 10 minutes in seconds
 	pub const MaxBlockWeight: u64 = MAXIMUM_BLOCK_WEIGHT.ref_time();
 	pub const MaxWeightPercentage: Perbill = SCHEDULED_TASKS_INITIALIZE_RATIO;
 	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
@@ -891,7 +892,7 @@ impl pallet_automation_time::Config for Runtime {
 	// Roughly .125% of parachain block weight per hour
 	// ≈ 500_000_000_000 (MaxBlockWeight) * 300 (Blocks/Hour) * .00125
 	type MaxWeightPerSlot = ConstU128<150_000_000_000>;
-	type SlotSizeSeconds = ConstU64<600>;
+	type SlotSizeSeconds = SlotSizeSeconds;
 	type UpdateQueueRatio = UpdateQueueRatio;
 	type WeightInfo = pallet_automation_time::weights::SubstrateWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -51,7 +51,7 @@ use frame_support::{
 	dispatch::DispatchClass,
 	ensure, parameter_types,
 	traits::{
-		ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
+		ConstU128, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
 		EnsureOriginWithArg, InstanceFilter, PrivilegeCmp,
 	},
 	weights::{

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -891,7 +891,7 @@ impl pallet_automation_time::Config for Runtime {
 	// Roughly .125% of parachain block weight per hour
 	// ≈ 500_000_000_000 (MaxBlockWeight) * 300 (Blocks/Hour) * .00125
 	type MaxWeightPerSlot = ConstU128<150_000_000_000>;
-	type SlotPeriod = ConstU64<600>;
+	type SlotSizeSeconds = ConstU64<600>;
 	type UpdateQueueRatio = UpdateQueueRatio;
 	type WeightInfo = pallet_automation_time::weights::SubstrateWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -51,7 +51,7 @@ use frame_support::{
 	dispatch::DispatchClass,
 	ensure, parameter_types,
 	traits::{
-		ConstU128, ConstU64, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
+		ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
 		EnsureOriginWithArg, InstanceFilter, PrivilegeCmp,
 	},
 	weights::{

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -52,7 +52,7 @@ use frame_support::{
 	dispatch::DispatchClass,
 	ensure, parameter_types,
 	traits::{
-		ConstU128, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
+		ConstU128, ConstU64, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
 		EnsureOriginWithArg, InstanceFilter, PrivilegeCmp,
 	},
 	weights::{
@@ -911,6 +911,7 @@ impl pallet_automation_time::Config for Runtime {
 	// Roughly .125% of parachain block weight per hour
 	// ≈ 500_000_000_000 (MaxBlockWeight) * 300 (Blocks/Hour) * .00125
 	type MaxWeightPerSlot = ConstU128<150_000_000_000>;
+	type SlotPeriod = ConstU64<600>;
 	type UpdateQueueRatio = UpdateQueueRatio;
 	type WeightInfo = pallet_automation_time::weights::SubstrateWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -52,7 +52,7 @@ use frame_support::{
 	dispatch::DispatchClass,
 	ensure, parameter_types,
 	traits::{
-		ConstU128, ConstU64, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
+		ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
 		EnsureOriginWithArg, InstanceFilter, PrivilegeCmp,
 	},
 	weights::{

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -52,7 +52,7 @@ use frame_support::{
 	dispatch::DispatchClass,
 	ensure, parameter_types,
 	traits::{
-		ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
+		ConstU128, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
 		EnsureOriginWithArg, InstanceFilter, PrivilegeCmp,
 	},
 	weights::{
@@ -855,7 +855,8 @@ impl pallet_democracy::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MaxScheduleSeconds: u64 = 6 * 30 * 24 * 60 * 60;
+	pub const MaxScheduleSeconds: u64 = 6 * 30 * 24 * 60 * 60;	// 6 months in seconds
+	pub const SlotSizeSeconds: u64 = 600; // 10 minutes in seconds
 	pub const MaxBlockWeight: u64 = MAXIMUM_BLOCK_WEIGHT.ref_time();
 	pub const MaxWeightPercentage: Perbill = SCHEDULED_TASKS_INITIALIZE_RATIO;
 	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
@@ -911,7 +912,7 @@ impl pallet_automation_time::Config for Runtime {
 	// Roughly .125% of parachain block weight per hour
 	// ≈ 500_000_000_000 (MaxBlockWeight) * 300 (Blocks/Hour) * .00125
 	type MaxWeightPerSlot = ConstU128<150_000_000_000>;
-	type SlotSizeSeconds = ConstU64<600>;
+	type SlotSizeSeconds = SlotSizeSeconds;
 	type UpdateQueueRatio = UpdateQueueRatio;
 	type WeightInfo = pallet_automation_time::weights::SubstrateWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -911,7 +911,7 @@ impl pallet_automation_time::Config for Runtime {
 	// Roughly .125% of parachain block weight per hour
 	// ≈ 500_000_000_000 (MaxBlockWeight) * 300 (Blocks/Hour) * .00125
 	type MaxWeightPerSlot = ConstU128<150_000_000_000>;
-	type SlotPeriod = ConstU64<600>;
+	type SlotSizeSeconds = ConstU64<600>;
 	type UpdateQueueRatio = UpdateQueueRatio;
 	type WeightInfo = pallet_automation_time::weights::SubstrateWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -854,7 +854,8 @@ impl pallet_democracy::Config for Runtime {
 }
 
 parameter_types! {
-	pub const MaxScheduleSeconds: u64 = 6 * 30 * 24 * 60 * 60;
+	pub const MaxScheduleSeconds: u64 = 6 * 30 * 24 * 60 * 60;	// 6 months in seconds
+	pub const SlotSizeSeconds: u64 = 600; // 10 minutes in seconds
 	pub const MaxBlockWeight: u64 = MAXIMUM_BLOCK_WEIGHT.ref_time();
 	pub const MaxWeightPercentage: Perbill = SCHEDULED_TASKS_INITIALIZE_RATIO;
 	pub const UpdateQueueRatio: Perbill = Perbill::from_percent(50);
@@ -910,7 +911,7 @@ impl pallet_automation_time::Config for Runtime {
 	// Roughly .125% of parachain block weight per hour
 	// ≈ 500_000_000_000 (MaxBlockWeight) * 300 (Blocks/Hour) * .00125
 	type MaxWeightPerSlot = ConstU128<150_000_000_000>;
-	type SlotSizeSeconds = ConstU64<600>;
+	type SlotSizeSeconds = SlotSizeSeconds;
 	type UpdateQueueRatio = UpdateQueueRatio;
 	type WeightInfo = pallet_automation_time::weights::SubstrateWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -52,7 +52,7 @@ use frame_support::{
 	dispatch::DispatchClass,
 	ensure, parameter_types,
 	traits::{
-		ConstU128, ConstU64, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
+		ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
 		EnsureOriginWithArg, InstanceFilter, PrivilegeCmp,
 	},
 	weights::{

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -910,7 +910,7 @@ impl pallet_automation_time::Config for Runtime {
 	// Roughly .125% of parachain block weight per hour
 	// ≈ 500_000_000_000 (MaxBlockWeight) * 300 (Blocks/Hour) * .00125
 	type MaxWeightPerSlot = ConstU128<150_000_000_000>;
-	type SlotPeriod = ConstU64<600>;
+	type SlotSizeSeconds = ConstU64<600>;
 	type UpdateQueueRatio = UpdateQueueRatio;
 	type WeightInfo = pallet_automation_time::weights::SubstrateWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -52,7 +52,7 @@ use frame_support::{
 	dispatch::DispatchClass,
 	ensure, parameter_types,
 	traits::{
-		ConstU128, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
+		ConstU128, ConstU64, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
 		EnsureOriginWithArg, InstanceFilter, PrivilegeCmp,
 	},
 	weights::{
@@ -910,6 +910,7 @@ impl pallet_automation_time::Config for Runtime {
 	// Roughly .125% of parachain block weight per hour
 	// ≈ 500_000_000_000 (MaxBlockWeight) * 300 (Blocks/Hour) * .00125
 	type MaxWeightPerSlot = ConstU128<150_000_000_000>;
+	type SlotPeriod = ConstU64<600>;
 	type UpdateQueueRatio = UpdateQueueRatio;
 	type WeightInfo = pallet_automation_time::weights::SubstrateWeight<Runtime>;
 	type ExecutionWeightFee = ExecutionWeightFee;

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -52,7 +52,7 @@ use frame_support::{
 	dispatch::DispatchClass,
 	ensure, parameter_types,
 	traits::{
-		ConstU128, ConstU16, ConstU32, ConstU64, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
+		ConstU128, ConstU16, ConstU32, ConstU8, Contains, EitherOfDiverse, EnsureOrigin,
 		EnsureOriginWithArg, InstanceFilter, PrivilegeCmp,
 	},
 	weights::{


### PR DESCRIPTION
### Screenshot

<img width="777" alt="image" src="https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/da36f9a2-b0c5-4169-8ec6-928520dcd096">

<img width="528" alt="image" src="https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/aba080ff-a200-492e-8f6b-29be4cbeded4">

<img width="1068" alt="image" src="https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/b8e5dfa1-1896-4f67-9bff-0f1fe1e31fcf">

### Test

```
running 120 tests
test autocompounding::tests::test_6 ... ok
test autocompounding::tests::test_5 ... ok
test autocompounding::tests::test_3 ... ok
test autocompounding::tests::test_2 ... ok
test autocompounding::tests::test_1 ... ok
test autocompounding::tests::test_9 ... ok
test autocompounding::tests::test_7 ... ok
test autocompounding::tests::test_4 ... ok
test autocompounding::tests::test_8 ... ok
test benchmarking::bench_run_dynamic_dispatch_action ... ok
test benchmarking::bench_run_dynamic_dispatch_action_fail_decode ... ok
test benchmarking::bench_force_cancel_scheduled_task ... ok
test benchmarking::bench_cancel_scheduled_task_full ... ok
test benchmarking::bench_run_missed_tasks_many_found ... ok
test benchmarking::bench_run_auto_compound_delegated_stake_task ... ok
test benchmarking::bench_force_cancel_scheduled_task_full ... ok
test benchmarking::bench_append_to_missed_tasks ... ok
test benchmarking::bench_run_tasks_many_missing ... ok
test benchmarking::bench_run_missed_tasks_many_missing ... ok
test benchmarking::bench_run_tasks_many_found ... ok
test benchmarking::bench_run_xcmp_task ... ok
test benchmarking::bench_schedule_auto_compound_delegated_stake_task_full ... ok
test benchmarking::bench_update_task_queue_overhead ... ok
test fees::tests::does_not_charge_fees_when_prereq_errors ... ok
test benchmarking::bench_shift_missed_tasks ... ok
test benchmarking::bench_update_scheduled_task_queue ... ok
test fees::tests::errors_when_not_enough_funds_for_fee ... ok
test mock::__construct_runtime_integrity_test::runtime_integrity_tests ... ok
test fees::tests::pay_checked_fees_for_success ... ok
test tests::auto_compound_delegated_stake_enough_balance_no_delegation ... ok
test benchmarking::bench_schedule_dynamic_dispatch_task ... ok
test tests::auto_compound_delegated_stake_enough_balance_no_delegator ... ok
test benchmarking::bench_schedule_dynamic_dispatch_task_full ... ok
test tests::calculate_dynamic_dispatch_action_schedule_fee_amount_works ... ok
test tests::calculate_auto_compound_action_schedule_fee_amount_works ... ok
test tests::auto_compound_delegated_stake_enough_balance_has_delegation ... ok
test tests::auto_compound_delegated_stake_not_enough_balance_has_delegation ... ok
test tests::calculate_xcmp_action_schedule_fee_amount_with_different_destination_returns_same_result ... ok
test tests::calculate_xcmp_action_schedule_fee_amount_with_different_execution_fee_returns_same_result ... ok
test tests::calculate_xcmp_action_schedule_fee_amount_with_different_instruction_sequence_returns_same_result ... ok
test tests::auto_compound_delegated_stake_not_enough_balance_no_delegation ... ok
test tests::calculate_xcmp_action_schedule_fee_amount_with_different_schedule_as_returns_same_result ... ok
test tests::calculate_xcmp_action_schedule_fee_amount_with_absolute_or_relative_native_schedule_fee_works ... ok
test benchmarking::bench_schedule_xcmp_task_full ... ok
test tests::calculate_xcmp_action_schedule_fee_amount_with_different_schedule_fees_works ... ok
test tests::calculate_xcmp_action_schedule_fee_amount_works ... ok
test tests::calculate_xcmp_action_schedule_fee_amount_with_unknown_schedule_fees_fails ... ok
test tests::cancel_task_must_exist ... ok
test tests::cancel_task_not_found ... ok
test tests::cancel_works_for_an_executed_task ... ok
test tests::cancel_works_for_tasks_in_queue ... ok
test tests::cancel_works_for_fixed_scheduled ... ok
test tests::cancel_task_fail_non_owner ... ok
test tests::cancel_works_for_multiple_executions_scheduled ... ok
test tests::extrinsics::schedule_dynamic_dispatch_task::works ... ok
test tests::missed_tasks_removes_completed_tasks ... ok
test tests::cancel_works_for_recurring_scheduled ... ok
test tests::missed_tasks_updates_executions_left ... ok
test tests::get_auto_compound_delegated_stake_task_ids_return_only_auto_compount_task_id ... ok
test tests::force_cancel_task_works ... ok
test tests::run_dynamic_dispatch_action::call_errors ... ok
test tests::on_init_shutdown ... ok
test tests::run_dynamic_dispatch_action::cannot_decode ... ok
test tests::on_init_runs_tasks ... ok
test tests::on_init_check_task_queue ... ok
test tests::run_dynamic_dispatch_action::call_filtered ... ok
test tests::run_dynamic_dispatch_action::call_works ... ok
test tests::schedule_auto_compound_delegated_stake ... ok
test tests::schedule_auto_compound_with_high_frequency ... ok
test tests::schedule_invalid_time_fixed_schedule ... ok
test tests::schedule_invalid_time_recurring_schedule ... ok
test tests::schedule_auto_compound_with_bad_frequency_or_execution_time ... ok
test tests::schedule_not_enough_for_fees ... ok
test tests::schedule_duplicates_errors ... ok
test tests::schedule_max_execution_times_errors ... ok
test tests::schedule_past_time_recurring ... ok
test tests::schedule_execution_times_removes_dupes ... ok
test tests::schedule_past_time ... ok
test tests::schedule_too_far_out ... ok
test tests::schedule_time_slot_full ... ok
test tests::schedule_transfer_with_dynamic_dispatch ... ok
test tests::schedule_xcmp_fails_if_not_enough_funds ... ok
test tests::schedule_time_slot_full_rolls_back ... ok
test tests::schedule_xcmp_through_proxy_same_as_delegator_account ... ok
test tests::schedule_xcmp_through_proxy_works ... ok
test tests::schedule_xcmp_works ... ok
test tests::taskid_adjusted_on_eventindex_on_same_block_from_same_caller ... ok
test tests::taskid_adjusted_on_extrinsicid_on_same_block ... ok
test tests::trigger_tasks_completes_all_tasks ... ok
test tests::trigger_tasks_completes_all_missed_tasks ... ok
test tests::taskid_on_same_extrinsid_have_unique_event_index ... ok
test tests::trigger_tasks_completes_auto_compound_delegated_stake_task ... ok
test tests::taskid_changed_per_block ... ok
test tests::trigger_tasks_handles_nonexisting_tasks ... ok
test tests::trigger_tasks_completes_some_tasks ... ok
test tests::trigger_tasks_completes_some_xcmp_tasks ... ok
test tests::trigger_tasks_handles_first_run ... ok
test tests::trigger_tasks_nothing_to_do ... ok
test tests::trigger_tasks_updates_executions_left ... ok
test tests::trigger_tasks_removes_completed_tasks ... ok
test tests::trigger_tasks_handles_missed_slots ... ok
test types::tests::schedule::checks_for_recurring_schedule_validity ... ok
test tests::trigger_tasks_updates_queues ... ok
test types::tests::schedule::checks_for_fixed_schedule_validity ... ok
test tests::will_not_emit_task_completed_event_when_task_canceled ... ok
test types::tests::schedule::new_fixed_schedule_cleans_execution_times ... ok
test types::tests::schedule::new_fixed_schedule_sets_executions_left ... ok
test types::tests::schedule::number_of_known_executions_for_fixed ... ok
test types::tests::schedule::new_fixed_schedule_errors_with_too_many_executions ... ok
test tests::will_emit_task_completed_event_when_task_completed ... ok
test types::tests::schedule_param::counts_executions ... ok
test types::tests::schedule::number_of_known_executions_for_recurring ... ok
test tests::will_emit_task_completed_event_when_task_failed ... ok
test types::tests::schedule_param::validates_fixed_schedule ... ok
test tests::trigger_tasks_limits_missed_slots ... ok
test types::tests::schedule_param::sets_executions_left ... ok
test types::tests::scheduled_tasks::try_push_works_when_slot_is_not_full ... ok
test types::tests::scheduled_tasks::try_push_errors_when_slot_is_full_by_task_count ... ok
test types::tests::scheduled_tasks::try_push_errors_when_slot_is_full_by_weight ... ok
test types::tests::schedule_param::validates_recurring_schedule ... ok
```
