### PR TITLE
Remove get_time_automation_fees RPC function

### DIFF
--- a/pallets/automation-time/rpc/runtime-api/src/lib.rs
+++ b/pallets/automation-time/rpc/runtime-api/src/lib.rs
@@ -54,7 +54,6 @@ sp_api::decl_runtime_apis! {
 		Balance: Codec,
 	{
 		fn query_fee_details(uxt: Block::Extrinsic) -> Result<FeeDetails<Balance>, Vec<u8>>;
-		fn get_time_automation_fees(action: AutomationAction, executions: u32) -> Balance;
 		fn calculate_optimal_autostaking(
 			principal: i128,
 			collator: AccountId

--- a/pallets/automation-time/rpc/src/lib.rs
+++ b/pallets/automation-time/rpc/src/lib.rs
@@ -43,14 +43,6 @@ pub trait AutomationTimeApi<BlockHash, AccountId, Hash, Balance> {
 		at: Option<BlockHash>,
 	) -> RpcResult<FeeDetails<NumberOrHex>>;
 
-	#[method(name = "automationTime_getTimeAutomationFees")]
-	fn get_time_automation_fees(
-		&self,
-		action: AutomationAction,
-		executions: u32,
-		at: Option<BlockHash>,
-	) -> RpcResult<u64>;
-
 	/// Returns optimal autostaking period based on principal and a target collator.
 	#[method(name = "automationTime_calculateOptimalAutostaking")]
 	fn caclulate_optimal_autostaking(
@@ -151,33 +143,6 @@ where
 		Ok(FeeDetails {
 			schedule_fee: try_into_rpc_balance(fee_details.schedule_fee)?,
 			execution_fee: try_into_rpc_balance(fee_details.execution_fee)?,
-		})
-	}
-
-	fn get_time_automation_fees(
-		&self,
-		action: AutomationAction,
-		executions: u32,
-		at: Option<<Block as BlockT>::Hash>,
-	) -> RpcResult<u64> {
-		let api = self.client.runtime_api();
-		let at = BlockId::hash(at.unwrap_or_else(||
-			// If the block hash is not supplied assume the best block.
-			self.client.info().best_hash));
-		let runtime_api_result =
-			api.get_time_automation_fees(&at, action, executions).map_err(|e| {
-				CallError::Custom(ErrorObject::owned(
-					Error::RuntimeError.into(),
-					"Unable to get time automation fees",
-					Some(e.to_string()),
-				))
-			})?;
-		runtime_api_result.try_into().map_err(|_| {
-			JsonRpseeError::Call(CallError::Custom(ErrorObject::owned(
-				Error::RuntimeError.into(),
-				"RPC value doesn't fit in u64 representation",
-				Some("RPC value cannot be translated into u64 representation".to_string()),
-			)))
 		})
 	}
 

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -1196,22 +1196,6 @@ impl_runtime_apis! {
 			})
 		}
 
-		/**
-		 * The get_time_automation_fees RPC function is used to get the execution fee of scheduling a time-automation task.
-		 * This function requires the action type and the number of executions in order to generate an estimate.
-		 * However, the AutomationTime::calculate_schedule_fee_amount requires an Action enum from the automation time pallet,
-		 * which requires more information than is necessary for this calculation.
-		 * Therefore, for ease of use, this function will just require an integer representing the action type and an integer
-		 * representing the number of executions. For all of the extraneous information, the function will provide faux inputs for it.
-		 *
-		 */
-		 fn get_time_automation_fees(
-			action: AutomationAction,
-			executions: u32,
-		) -> Balance {
-			AutomationTime::calculate_schedule_fee_amount(&(action.into()), executions).expect("Can only fail for DynamicDispatch which is not an option here")
-		}
-
 		fn calculate_optimal_autostaking(
 			principal: i128,
 			collator: AccountId

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -1201,22 +1201,6 @@ impl_runtime_apis! {
 			})
 		}
 
-		/**
-		 * The get_time_automation_fees RPC function is used to get the execution fee of scheduling a time-automation task.
-		 * This function requires the action type and the number of executions in order to generate an estimate.
-		 * However, the AutomationTime::calculate_schedule_fee_amount requires an Action enum from the automation time pallet,
-		 * which requires more information than is necessary for this calculation.
-		 * Therefore, for ease of use, this function will just require an integer representing the action type and an integer
-		 * representing the number of executions. For all of the extraneous information, the function will provide faux inputs for it.
-		 *
-		 */
-		fn get_time_automation_fees(
-			action: AutomationAction,
-			executions: u32,
-		) -> Balance {
-			AutomationTime::calculate_schedule_fee_amount(&(action.into()), executions).expect("Can only fail for DynamicDispatch which is not an option here")
-		}
-
 		fn calculate_optimal_autostaking(
 			principal: i128,
 			collator: AccountId

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -1220,22 +1220,6 @@ impl_runtime_apis! {
 			})
 		}
 
-		/**
-		 * The get_time_automation_fees RPC function is used to get the execution fee of scheduling a time-automation task.
-		 * This function requires the action type and the number of executions in order to generate an estimate.
-		 * However, the AutomationTime::calculate_schedule_fee_amount requires an Action enum from the automation time pallet,
-		 * which requires more information than is necessary for this calculation.
-		 * Therefore, for ease of use, this function will just require an integer representing the action type and an integer
-		 * representing the number of executions. For all of the extraneous information, the function will provide faux inputs for it.
-		 *
-		 */
-		fn get_time_automation_fees(
-			action: AutomationAction,
-			executions: u32,
-		) -> Balance {
-			AutomationTime::calculate_schedule_fee_amount(&(action.into()), executions).expect("Can only fail for DynamicDispatch which is not an option here")
-		}
-
 		fn calculate_optimal_autostaking(
 			principal: i128,
 			collator: AccountId


### PR DESCRIPTION
Because the query_fee_details function returns both schedule_fee and execution_fee, while get_time_automation_fees only returns schedule_fee.

we should keep only query_fee_details and remove get_time_automation_fees.