### PR TITLE
add missing dev-queue flag for automation price

### DIFF
--- a/runtime/turing/Cargo.toml
+++ b/runtime/turing/Cargo.toml
@@ -257,4 +257,7 @@ try-runtime = [
   "parachain-info/try-runtime",
 ]
 
-dev-queue = ["pallet-automation-time/dev-queue"]
+dev-queue = [
+  "pallet-automation-time/dev-queue",
+  "pallet-automation-price/dev-queue"
+]


### PR DESCRIPTION
I had miss this flag when I originally introduce the `dev-queue` to automation price so non root user can initialize asset during development.

