### PR TITLE
Specify the currency for the execution fee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7110,12 +7110,15 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
+ "orml-currencies",
+ "orml-tokens",
  "orml-traits",
  "pallet-balances",
  "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",
  "polkadot-parachain",
+ "primitives",
  "scale-info",
  "serde",
  "sp-core",
@@ -8767,11 +8770,15 @@ dependencies = [
 name = "primitives"
 version = "1.0.0"
 dependencies = [
+ "frame-support",
+ "orml-traits",
  "parity-scale-codec",
  "scale-info",
  "sp-consensus-aura",
  "sp-core",
  "sp-runtime",
+ "sp-std",
+ "xcm",
 ]
 
 [[package]]

--- a/pallets/automation-price/src/fees.rs
+++ b/pallets/automation-price/src/fees.rs
@@ -101,9 +101,8 @@ where
 
 		let currency_id = T::CurrencyIdConvert::convert(self.schedule_fee_location)
 			.ok_or("IncoveribleMultilocation")?;
-		let currency_id = currency_id.into();
 
-		match T::MultiCurrency::withdraw(currency_id, &self.owner, fee) {
+		match T::MultiCurrency::withdraw(currency_id.into(), &self.owner, fee) {
 			Ok(_) => {
 				TR::take_revenue(MultiAsset {
 					id: AssetId::Concrete(self.schedule_fee_location),
@@ -112,6 +111,7 @@ where
 
 				if self.execution_fee_amount > MultiBalanceOf::<T>::zero() {
 					T::XcmpTransactor::pay_xcm_fee(
+						currency_id,
 						self.owner.clone(),
 						self.execution_fee_amount.saturated_into(),
 					)?;

--- a/pallets/automation-price/src/mock.rs
+++ b/pallets/automation-price/src/mock.rs
@@ -322,7 +322,11 @@ where
 		Ok(())
 	}
 
-	fn pay_xcm_fee(_: T::AccountId, _: u128) -> Result<(), sp_runtime::DispatchError> {
+	fn pay_xcm_fee(
+		_: CurrencyId,
+		_: T::AccountId,
+		_: u128,
+	) -> Result<(), sp_runtime::DispatchError> {
 		Ok(())
 	}
 }

--- a/pallets/automation-time/src/fees.rs
+++ b/pallets/automation-time/src/fees.rs
@@ -150,6 +150,8 @@ where
 		log::debug!(target: "FeeHandler", "FeeHandler::withdraw_fee, self.schedule_fee.asset_location: {:?}, self.schedule_fee.amount: {:?}",
 			self.schedule_fee.asset_location, self.schedule_fee.amount);
 		// Withdraw schedule fee
+		// When the expected deduction amount, schedule_fee_amount, is not equal to zero, execute the withdrawal process;
+		// otherwise, there’s no need to deduct.
 		if !self.schedule_fee.amount.is_zero() {
 			let currency_id = T::CurrencyIdConvert::convert(self.schedule_fee.asset_location)
 				.ok_or("InconvertibleMultilocation")?;
@@ -172,6 +174,8 @@ where
 					.ok_or("InconvertibleMultilocation")?;
 
 				let execution_fee_amount = execution_fee.amount;
+				// When the expected deduction amount, execution_fee_amount, is not equal to zero, execute the withdrawal process;
+				// otherwise, there’s no need to deduct.
 				if !execution_fee_amount.is_zero() {
 					T::XcmpTransactor::pay_xcm_fee(
 						currency_id,

--- a/pallets/automation-time/src/fees.rs
+++ b/pallets/automation-time/src/fees.rs
@@ -130,6 +130,7 @@ where
 						self.schedule_fee.asset_location,
 						self.schedule_fee.amount,
 					)?;
+					Self::ensure_can_withdraw(self, exec_fee.asset_location, exec_fee.amount)?;
 				}
 			},
 			_ => {

--- a/pallets/automation-time/src/fees.rs
+++ b/pallets/automation-time/src/fees.rs
@@ -255,18 +255,18 @@ mod tests {
 
 			let call: <Test as frame_system::Config>::RuntimeCall =
 				frame_system::Call::remark_with_event { remark: vec![50] }.into();
-			let mut spy = 0;
+			let mut has_callback_run = false;
 			let result = <Test as crate::Config>::FeeHandler::pay_checked_fees_for(
 				&alice,
 				&Action::DynamicDispatch { encoded_call: call.encode() },
 				1,
 				|| {
-					spy += 1;
+					has_callback_run = true;
 					Ok("called")
 				},
 			);
 			assert_eq!(result.expect("success"), "called");
-			assert_eq!(spy, 1);
+			assert_eq!(has_callback_run, true);
 			assert!(starting_funds > Balances::free_balance(alice))
 		})
 	}
@@ -276,7 +276,7 @@ mod tests {
 		new_test_ext(0).execute_with(|| {
 			let destination = MultiLocation::new(1, X1(Parachain(PARA_ID)));
 			let alice = AccountId32::new(ALICE);
-			let mut spy = 0;
+			let mut has_callback_run = false;
 			get_multi_xcmp_funds(alice.clone());
 
 			let action = Action::XCMP {
@@ -295,12 +295,12 @@ mod tests {
 				&action,
 				1,
 				|| {
-					spy += 1;
+					has_callback_run = true;
 					Ok("called")
 				},
 			);
 			assert_eq!(result.expect("success"), "called");
-			assert_eq!(spy, 1);
+			assert_eq!(has_callback_run, true);
 		})
 	}
 
@@ -337,7 +337,7 @@ mod tests {
 		new_test_ext(0).execute_with(|| {
 			let destination = MultiLocation::new(1, X1(Parachain(PARA_ID)));
 			let alice = AccountId32::new(ALICE);
-			let mut spy = 0;
+			let mut has_callback_run = false;
 			fund_account(&alice, 900_000_000, 1, Some(0));
 
 			let action = Action::XCMP {
@@ -356,12 +356,12 @@ mod tests {
 				&action,
 				1,
 				|| {
-					spy += 1;
+					has_callback_run = true;
 					Ok("called")
 				},
 			);
 			assert_eq!(result.expect("success"), "called");
-			assert_eq!(spy, 1);
+			assert_eq!(has_callback_run, true);
 		})
 	}
 

--- a/pallets/automation-time/src/fees.rs
+++ b/pallets/automation-time/src/fees.rs
@@ -126,6 +126,8 @@ where
 
 	/// Withdraw the fee.
 	fn withdraw_fee(&self) -> Result<(), DispatchError> {
+		log::debug!(target: "FeeHandler", "FeeHandler::withdraw_fee, self.schedule_fee.asset_location: {:?}, self.schedule_fee.amount: {:?}",
+			self.schedule_fee.asset_location, self.schedule_fee.amount);
 		// Withdraw schedule fee
 		if !self.schedule_fee.amount.is_zero() {
 			let currency_id = T::CurrencyIdConvert::convert(self.schedule_fee.asset_location)
@@ -143,18 +145,13 @@ where
 		// Withdraw execution fee
 		if let Some(execution_fee) = &self.execution_fee {
 			if execution_fee.is_local {
+				log::debug!(target: "FeeHandler", "FeeHandler::withdraw_fee, self.execution_fee.asset_location: {:?}, self.execution_fee.amount: {:?}",
+					execution_fee.asset_location, execution_fee.amount);
 				let currency_id = T::CurrencyIdConvert::convert(execution_fee.asset_location)
 					.ok_or("InconvertibleMultilocation")?;
 
 				let execution_fee_amount = execution_fee.amount;
 				if !execution_fee_amount.is_zero() {
-					// T::MultiCurrency::withdraw(
-					// 	currency_id.into(),
-					// 	&self.owner,
-					// 	execution_fee_amount,
-					// )
-					// .map_err(|_| DispatchError::Token(BelowMinimum))?;
-
 					T::XcmpTransactor::pay_xcm_fee(
 						currency_id,
 						self.owner.clone(),

--- a/pallets/automation-time/src/fees.rs
+++ b/pallets/automation-time/src/fees.rs
@@ -39,11 +39,18 @@ pub trait HandleFees<T: Config> {
 	) -> Result<R, DispatchError>;
 }
 
+#[derive(Clone)]
+pub struct FeePayment<T: Config> {
+	pub asset_location: MultiLocation,
+	pub amount: MultiBalanceOf<T>,
+	pub is_local_deduction: bool,
+}
+
 pub struct FeeHandler<T: Config, TR> {
 	owner: T::AccountId,
 	pub schedule_fee_location: MultiLocation,
 	pub schedule_fee_amount: MultiBalanceOf<T>,
-	pub execution_fee_amount: MultiBalanceOf<T>,
+	pub execution_fee: Option<FeePayment<T>>,
 	_phantom_data: PhantomData<TR>,
 }
 
@@ -73,57 +80,89 @@ where
 {
 	/// Ensure the fee can be paid.
 	fn can_pay_fee(&self) -> Result<(), DispatchError> {
-		let fee = self.schedule_fee_amount.saturating_add(self.execution_fee_amount);
+		let mut additional_fee = MultiBalanceOf::<T>::zero();
+
+		if let Some(exec_fee) = &self.execution_fee {
+			if exec_fee.is_local_deduction && exec_fee.asset_location == self.schedule_fee_location
+			{
+				additional_fee = exec_fee.amount;
+			} else if !exec_fee.amount.is_zero() {
+				let currency_id = T::CurrencyIdConvert::convert(exec_fee.asset_location)
+					.ok_or("IncoveribleMultilocation")?;
+				let free_balance = T::MultiCurrency::free_balance(currency_id.into(), &self.owner);
+				let min_balance = T::MultiCurrency::minimum_balance(currency_id.into());
+
+				free_balance
+					.checked_sub(&exec_fee.amount)
+					.and_then(|balance_minus_fee| balance_minus_fee.checked_sub(&min_balance))
+					.ok_or(DispatchError::Token(BelowMinimum))?;
+			}
+		}
+
+		let fee = self.schedule_fee_amount.saturating_add(additional_fee);
 
 		if fee.is_zero() {
 			return Ok(())
 		}
 
-		// Manually check for ExistenceRequirement since MultiCurrency doesn't currently support it
-		let currency_id = T::CurrencyIdConvert::convert(self.schedule_fee_location)
-			.ok_or("IncoveribleMultilocation")?;
-		let currency_id = currency_id.into();
-		let free_balance = T::MultiCurrency::free_balance(currency_id, &self.owner);
+		let schedule_currency_id = T::CurrencyIdConvert::convert(self.schedule_fee_location)
+			.ok_or("IncoveribleMultilocation")?
+			.into();
+		let free_balance = T::MultiCurrency::free_balance(schedule_currency_id, &self.owner);
 
 		free_balance
 			.checked_sub(&fee)
-			.ok_or(DispatchError::Token(BelowMinimum))?
-			.checked_sub(&T::MultiCurrency::minimum_balance(currency_id))
+			.and_then(|balance_minus_fee| {
+				balance_minus_fee
+					.checked_sub(&T::MultiCurrency::minimum_balance(schedule_currency_id))
+			})
 			.ok_or(DispatchError::Token(BelowMinimum))?;
-		T::MultiCurrency::ensure_can_withdraw(currency_id, &self.owner, fee)?;
+
+		T::MultiCurrency::ensure_can_withdraw(schedule_currency_id, &self.owner, fee)?;
+
 		Ok(())
 	}
 
 	/// Withdraw the fee.
 	fn withdraw_fee(&self) -> Result<(), DispatchError> {
-		let fee = self.schedule_fee_amount.saturating_add(self.execution_fee_amount);
+		// Withdraw schedule fee
+		if !self.schedule_fee_amount.is_zero() {
+			let currency_id = T::CurrencyIdConvert::convert(self.schedule_fee_location)
+				.ok_or("InconvertibleMultilocation")?;
 
-		if fee.is_zero() {
-			return Ok(())
+			T::MultiCurrency::withdraw(currency_id.into(), &self.owner, self.schedule_fee_amount)
+				.map_err(|_| DispatchError::Token(BelowMinimum))?;
+
+			TR::take_revenue(MultiAsset {
+				id: AssetId::Concrete(self.schedule_fee_location),
+				fun: Fungibility::Fungible(self.schedule_fee_amount.saturated_into()),
+			});
 		}
 
-		let currency_id = T::CurrencyIdConvert::convert(self.schedule_fee_location)
-			.ok_or("IncoveribleMultilocation")?;
-		let currency_id = currency_id.into();
+		// Withdraw execution fee
+		if let Some(execution_fee) = &self.execution_fee {
+			if execution_fee.is_local_deduction {
+				let currency_id = T::CurrencyIdConvert::convert(execution_fee.asset_location)
+					.ok_or("InconvertibleMultilocation")?;
 
-		match T::MultiCurrency::withdraw(currency_id, &self.owner, fee) {
-			Ok(_) => {
-				TR::take_revenue(MultiAsset {
-					id: AssetId::Concrete(self.schedule_fee_location),
-					fun: Fungibility::Fungible(self.schedule_fee_amount.saturated_into()),
-				});
+				let execution_fee_amount = execution_fee.amount;
+				if !execution_fee_amount.is_zero() {
+					T::MultiCurrency::withdraw(
+						currency_id.into(),
+						&self.owner,
+						execution_fee_amount,
+					)
+					.map_err(|_| DispatchError::Token(BelowMinimum))?;
 
-				if self.execution_fee_amount > MultiBalanceOf::<T>::zero() {
 					T::XcmpTransactor::pay_xcm_fee(
 						self.owner.clone(),
-						self.execution_fee_amount.saturated_into(),
+						execution_fee_amount.saturated_into(),
 					)?;
 				}
-
-				Ok(())
-			},
-			Err(_) => Err(DispatchError::Token(BelowMinimum)),
+			}
 		}
+
+		Ok(())
 	}
 
 	/// Builds an instance of the struct
@@ -137,18 +176,24 @@ where
 		let schedule_fee_amount: u128 =
 			Pallet::<T>::calculate_schedule_fee_amount(action, executions)?.saturated_into();
 
-		let execution_fee_amount = match action.clone() {
+		let execution_fee = match action.clone() {
 			Action::XCMP { execution_fee, instruction_sequence, .. }
 				if instruction_sequence == InstructionSequence::PayThroughSovereignAccount =>
-				execution_fee.amount.saturating_mul(executions.into()).saturated_into(),
-			_ => 0u32.saturated_into(),
+			{
+				let location = MultiLocation::try_from(execution_fee.asset_location)
+					.map_err(|()| Error::<T>::BadVersion)?;
+				let amount =
+					execution_fee.amount.saturating_mul(executions.into()).saturated_into();
+				Some(FeePayment { asset_location: location, amount, is_local_deduction: true })
+			},
+			_ => None,
 		};
 
 		Ok(Self {
 			owner: owner.clone(),
 			schedule_fee_location,
 			schedule_fee_amount: schedule_fee_amount.saturated_into(),
-			execution_fee_amount,
+			execution_fee,
 			_phantom_data: Default::default(),
 		})
 	}

--- a/pallets/automation-time/src/fees.rs
+++ b/pallets/automation-time/src/fees.rs
@@ -147,14 +147,15 @@ where
 
 				let execution_fee_amount = execution_fee.amount;
 				if !execution_fee_amount.is_zero() {
-					T::MultiCurrency::withdraw(
-						currency_id.into(),
-						&self.owner,
-						execution_fee_amount,
-					)
-					.map_err(|_| DispatchError::Token(BelowMinimum))?;
+					// T::MultiCurrency::withdraw(
+					// 	currency_id.into(),
+					// 	&self.owner,
+					// 	execution_fee_amount,
+					// )
+					// .map_err(|_| DispatchError::Token(BelowMinimum))?;
 
 					T::XcmpTransactor::pay_xcm_fee(
+						currency_id,
 						self.owner.clone(),
 						execution_fee_amount.saturated_into(),
 					)?;
@@ -177,9 +178,7 @@ where
 			Pallet::<T>::calculate_schedule_fee_amount(action, executions)?.saturated_into();
 
 		let execution_fee = match action.clone() {
-			Action::XCMP { execution_fee, instruction_sequence, .. }
-				if instruction_sequence == InstructionSequence::PayThroughSovereignAccount =>
-			{
+			Action::XCMP { execution_fee, instruction_sequence, .. } => {
 				let location = MultiLocation::try_from(execution_fee.asset_location)
 					.map_err(|()| Error::<T>::BadVersion)?;
 				let amount =

--- a/pallets/automation-time/src/fees.rs
+++ b/pallets/automation-time/src/fees.rs
@@ -78,14 +78,18 @@ where
 	T: Config,
 	TR: TakeRevenue,
 {
-
-	fn ensure_can_withdraw(&self, asset_location: MultiLocation, amount: MultiBalanceOf<T>) -> Result<(), DispatchError> {
+	fn ensure_can_withdraw(
+		&self,
+		asset_location: MultiLocation,
+		amount: MultiBalanceOf<T>,
+	) -> Result<(), DispatchError> {
 		if amount.is_zero() {
 			return Ok(())
 		}
 
 		let currency_id = T::CurrencyIdConvert::convert(asset_location)
-			.ok_or("IncoveribleMultilocation")?.into();
+			.ok_or("IncoveribleMultilocation")?
+			.into();
 		let free_balance = T::MultiCurrency::free_balance(currency_id, &self.owner);
 		let min_balance = T::MultiCurrency::minimum_balance(currency_id);
 
@@ -110,7 +114,11 @@ where
 				let fee = self.schedule_fee_amount.saturating_add(exec_fee.amount);
 				Self::ensure_can_withdraw(self, exec_fee.asset_location, fee)?;
 			} else {
-				Self::ensure_can_withdraw(self, self.schedule_fee_location, self.schedule_fee_amount)?;
+				Self::ensure_can_withdraw(
+					self,
+					self.schedule_fee_location,
+					self.schedule_fee_amount,
+				)?;
 				Self::ensure_can_withdraw(self, exec_fee.asset_location, exec_fee.amount)?;
 			}
 		}

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -59,10 +59,7 @@ use frame_support::{
 	weights::constants::WEIGHT_REF_TIME_PER_SECOND,
 };
 use frame_system::pallet_prelude::*;
-use orml_traits::{
-	location::{Parse, Reserve},
-	FixedConversionRateProvider, MultiCurrency,
-};
+use orml_traits::{location::Reserve, FixedConversionRateProvider, MultiCurrency};
 use pallet_parachain_staking::DelegatorActions;
 use pallet_timestamp::{self as timestamp};
 pub use pallet_xcmp_handler::InstructionSequence;
@@ -1560,6 +1557,9 @@ pub mod pallet {
 			Ok(fee)
 		}
 
+		/// Checks if the execution fee location is supported for scheduling a task
+		///
+		/// if the locations can not be verified, an error such as InvalidAssetLocation or UnsupportedFeePayment will be thrown
 		pub fn ensure_supported_execution_fee_location(
 			exeuction_fee_location: &MultiLocation,
 			destination: &MultiLocation,

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -1564,11 +1564,7 @@ pub mod pallet {
 			exeuction_fee_location: &MultiLocation,
 			destination: &MultiLocation,
 		) -> Result<(), DispatchError> {
-			let reserve = exeuction_fee_location.chain_part();
-			if reserve.is_none() {
-				return Err(Error::<T>::InvalidAssetLocation.into())
-			}
-			let reserve = reserve.unwrap();
+			let reserve = exeuction_fee_location.chain_part().ok_or(Error::<T>::InvalidAssetLocation)?;
 			let self_location = T::SelfLocation::get();
 			if reserve != self_location && &reserve != destination {
 				return Err(Error::<T>::UnsupportedFeePayment.into())

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -414,20 +414,20 @@ pub mod pallet {
 
 			Self::ensure_supported_execution_fee_location(&execution_fee_location, &destination)?;
 
-			// let action = Action::XCMP {
-			// 	destination,
-			// 	schedule_fee,
-			// 	execution_fee,
-			// 	encoded_call,
-			// 	encoded_call_weight,
-			// 	overall_weight,
-			// 	schedule_as: None,
-			// 	instruction_sequence: InstructionSequence::PayThroughSovereignAccount,
-			// };
+			let action = Action::XCMP {
+				destination,
+				schedule_fee,
+				execution_fee,
+				encoded_call,
+				encoded_call_weight,
+				overall_weight,
+				schedule_as: None,
+				instruction_sequence: InstructionSequence::PayThroughSovereignAccount,
+			};
 
-			// let schedule = schedule.validated_into::<T>()?;
+			let schedule = schedule.validated_into::<T>()?;
 
-			// Self::validate_and_schedule_task(action, who, schedule, vec![])?;
+			Self::validate_and_schedule_task(action, who, schedule, vec![])?;
 			Ok(())
 		}
 

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -1564,7 +1564,8 @@ pub mod pallet {
 			exeuction_fee_location: &MultiLocation,
 			destination: &MultiLocation,
 		) -> Result<(), DispatchError> {
-			let reserve = exeuction_fee_location.chain_part().ok_or(Error::<T>::InvalidAssetLocation)?;
+			let reserve =
+				exeuction_fee_location.chain_part().ok_or(Error::<T>::InvalidAssetLocation)?;
 			let self_location = T::SelfLocation::get();
 			if reserve != self_location && &reserve != destination {
 				return Err(Error::<T>::UnsupportedFeePayment.into())

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -275,7 +275,9 @@ pub mod pallet {
 		/// The version of the `VersionedMultiLocation` value used is not able
 		/// to be interpreted.
 		BadVersion,
+		// The fee payment asset location is not supported.
 		UnsupportedFeePayment,
+		// Mulilocation cannot be reanchored.
 		CannotReanchor,
 		/// Invalid asset location.
 		InvalidAssetLocation,
@@ -1562,12 +1564,13 @@ pub mod pallet {
 			exeuction_fee_location: &MultiLocation,
 			destination: &MultiLocation,
 		) -> Result<(), DispatchError> {
-			if exeuction_fee_location.chain_part().is_none() {
+			let reserve = exeuction_fee_location.chain_part();
+			if reserve.is_none() {
 				return Err(Error::<T>::InvalidAssetLocation.into())
 			}
-
+			let reserve = reserve.unwrap();
 			let self_location = T::SelfLocation::get();
-			if exeuction_fee_location != &self_location && exeuction_fee_location != destination {
+			if reserve != self_location && &reserve != destination {
 				return Err(Error::<T>::UnsupportedFeePayment.into())
 			}
 

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -265,7 +265,6 @@ pub mod pallet {
 		/// The version of the `VersionedMultiLocation` value used is not able
 		/// to be interpreted.
 		BadVersion,
-		UnsupportedFeePayment,
 		CannotReanchor,
 	}
 
@@ -373,7 +372,6 @@ pub mod pallet {
 		/// * `DuplicateTask`: There can be no duplicate tasks.
 		/// * `TimeTooFarOut`: Execution time or frequency are past the max time horizon.
 		/// * `TimeSlotFull`: Time slot is full. No more tasks can be scheduled for this time.
-		/// * `UnsupportedFeePayment`: Time slot is full. No more tasks can be scheduled for this time.
 		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_xcmp_task_full(schedule.number_of_executions()))]
 		pub fn schedule_xcmp_task(
@@ -430,7 +428,6 @@ pub mod pallet {
 		/// * `DuplicateTask`: There can be no duplicate tasks.
 		/// * `TimeTooFarOut`: Execution time or frequency are past the max time horizon.
 		/// * `TimeSlotFull`: Time slot is full. No more tasks can be scheduled for this time.
-		/// * `UnsupportedFeePayment`: Time slot is full. No more tasks can be scheduled for this time.
 		/// * `Other("proxy error: expected `ProxyType::Any`")`: schedule_as must be a proxy account of type "any" for the caller.
 		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_xcmp_task_full(schedule.number_of_executions()).saturating_add(T::DbWeight::get().reads(1)))]
@@ -1331,12 +1328,6 @@ pub mod pallet {
 							T::UniversalLocation::get(),
 						)
 						.map_err(|_| Error::<T>::CannotReanchor)?;
-					// Only native token are supported as the XCMP fee for local deductions
-					if instruction_sequence == InstructionSequence::PayThroughSovereignAccount &&
-						asset_location != MultiLocation::new(0, Here)
-					{
-						Err(Error::<T>::UnsupportedFeePayment)?
-					}
 				},
 				_ => (),
 			};

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -414,20 +414,20 @@ pub mod pallet {
 
 			Self::ensure_supported_execution_fee_location(&execution_fee_location, &destination)?;
 
-			let action = Action::XCMP {
-				destination,
-				schedule_fee,
-				execution_fee,
-				encoded_call,
-				encoded_call_weight,
-				overall_weight,
-				schedule_as: None,
-				instruction_sequence: InstructionSequence::PayThroughSovereignAccount,
-			};
+			// let action = Action::XCMP {
+			// 	destination,
+			// 	schedule_fee,
+			// 	execution_fee,
+			// 	encoded_call,
+			// 	encoded_call_weight,
+			// 	overall_weight,
+			// 	schedule_as: None,
+			// 	instruction_sequence: InstructionSequence::PayThroughSovereignAccount,
+			// };
 
-			let schedule = schedule.validated_into::<T>()?;
+			// let schedule = schedule.validated_into::<T>()?;
 
-			Self::validate_and_schedule_task(action, who, schedule, vec![])?;
+			// Self::validate_and_schedule_task(action, who, schedule, vec![])?;
 			Ok(())
 		}
 
@@ -1564,10 +1564,11 @@ pub mod pallet {
 			exeuction_fee_location: &MultiLocation,
 			destination: &MultiLocation,
 		) -> Result<(), DispatchError> {
-			let reserve =
-				exeuction_fee_location.chain_part().ok_or(Error::<T>::InvalidAssetLocation)?;
-			let self_location = T::SelfLocation::get();
-			if reserve != self_location && &reserve != destination {
+			let exeuction_fee =
+				MultiAsset { id: Concrete(*exeuction_fee_location), fun: Fungibility::Fungible(0) };
+			let reserve = T::ReserveProvider::reserve(&exeuction_fee)
+				.ok_or(Error::<T>::InvalidAssetLocation)?;
+			if reserve != MultiLocation::here() && &reserve != destination {
 				return Err(Error::<T>::UnsupportedFeePayment.into())
 			}
 

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -28,7 +28,7 @@ use frame_support::{
 };
 use frame_system::{self as system, EnsureRoot, RawOrigin};
 use orml_traits::parameter_type_with_key;
-use primitives::{EnsureProxy, TransferCallCreator};
+use primitives::{AbsoluteAndRelativeReserveProvider, EnsureProxy, TransferCallCreator};
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
@@ -398,7 +398,11 @@ where
 		Ok(())
 	}
 
-	fn pay_xcm_fee(_: T::AccountId, _: u128) -> Result<(), sp_runtime::DispatchError> {
+	fn pay_xcm_fee(
+		_: CurrencyId,
+		_: T::AccountId,
+		_: u128,
+	) -> Result<(), sp_runtime::DispatchError> {
 		Ok(())
 	}
 }
@@ -504,6 +508,7 @@ parameter_types! {
 	// The universal location within the global consensus system
 	pub UniversalLocation: InteriorMultiLocation =
 		X2(GlobalConsensus(RelayNetwork::get()), Parachain(ParachainInfo::parachain_id().into()));
+	pub SelfLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into())));
 }
 
 impl pallet_automation_time::Config for Test {
@@ -530,8 +535,9 @@ impl pallet_automation_time::Config for Test {
 	type FeeConversionRateProvider = MockConversionRateProvider;
 	type EnsureProxy = MockEnsureProxy;
 	type UniversalLocation = UniversalLocation;
-	type SelfParaId = parachain_info::Pallet<Test>;
 	type TransferCallCreator = MockTransferCallCreator;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
+	type SelfLocation = SelfLocation;
 }
 
 // Build genesis storage according to the mock runtime.
@@ -742,10 +748,7 @@ pub fn fund_account(
 
 pub fn get_fee_per_second(location: &MultiLocation) -> Option<u128> {
 	let location = location
-		.reanchored(
-			&MultiLocation::new(1, X1(Parachain(<Test as Config>::SelfParaId::get().into()))),
-			<Test as Config>::UniversalLocation::get(),
-		)
+		.reanchored(&SelfLocation::get(), <Test as Config>::UniversalLocation::get())
 		.expect("Reanchor location failed");
 
 	let found_asset = ASSET_FEE_PER_SECOND.into_iter().find(|item| match item {

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -721,6 +721,21 @@ pub fn get_xcmp_funds(account: AccountId) {
 	Balances::force_set_balance(RawOrigin::Root.into(), account, with_xcm_fees).unwrap();
 }
 
+pub fn get_multi_xcmp_funds(account: AccountId) {
+	let double_action_weight = MockWeight::<Test>::run_xcmp_task() * 2;
+	let action_fee = ExecutionWeightFee::get() * u128::from(double_action_weight.ref_time());
+	let max_execution_fee = action_fee * u128::from(MaxExecutionTimes::get());
+	Balances::force_set_balance(RawOrigin::Root.into(), account.clone(), max_execution_fee)
+		.unwrap();
+	Currencies::update_balance(
+		RawOrigin::Root.into(),
+		account,
+		FOREIGN_CURRENCY_ID,
+		XmpFee::get() as i64,
+	)
+	.unwrap();
+}
+
 // TODO: swap above to this pattern
 pub fn fund_account_dynamic_dispatch(
 	account: &AccountId,

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -117,10 +117,7 @@ fn calculate_expected_xcmp_action_schedule_fee(
 	num_of_execution: u32,
 ) -> u128 {
 	let schedule_fee_location = schedule_fee_location
-		.reanchored(
-			&MultiLocation::new(1, X1(Parachain(<Test as Config>::SelfParaId::get().into()))),
-			<Test as Config>::UniversalLocation::get(),
-		)
+		.reanchored(&SelfLocation::get(), <Test as Config>::UniversalLocation::get())
 		.expect("Location reanchor failed");
 	let weight = <Test as Config>::WeightInfo::run_xcmp_task();
 
@@ -859,10 +856,7 @@ fn calculate_xcmp_action_schedule_fee_amount_with_absolute_or_relative_native_sc
 		let num_of_execution = generate_random_num(1, 20);
 
 		let action_absolute = create_xcmp_action(XcmpActionParams {
-			schedule_fee: MultiLocation::new(
-				1,
-				X1(Parachain(<Test as Config>::SelfParaId::get().into())),
-			),
+			schedule_fee: SelfLocation::get(),
 			..XcmpActionParams::default()
 		});
 		let fee_amount_abosolute =

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -30,7 +30,6 @@ use frame_support::{
 };
 use frame_system::{self, RawOrigin};
 use rand::Rng;
-use sp_core::Get;
 use sp_runtime::{
 	traits::{BlakeTwo256, Hash},
 	AccountId32,
@@ -1046,10 +1045,7 @@ fn schedule_xcmp_through_proxy_works() {
 			ScheduleParam::Fixed { execution_times: vec![SCHEDULED_TIME] },
 			Box::new(destination.into()),
 			Box::new(MultiLocation::default().into()),
-			Box::new(AssetPayment {
-				asset_location: destination.into(),
-				amount: 10,
-			}),
+			Box::new(AssetPayment { asset_location: destination.into(), amount: 10 }),
 			call,
 			Weight::from_parts(100_000, 0),
 			Weight::from_parts(200_000, 0),

--- a/pallets/xcmp-handler/Cargo.toml
+++ b/pallets/xcmp-handler/Cargo.toml
@@ -42,6 +42,8 @@ xcm-executor = { git = "https://github.com/paritytech/polkadot", default-feature
 
 # ORML
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.43" }
+orml-currencies = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.43" }
+orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.43" }
 
 [dev-dependencies]
 # Substrate
@@ -57,6 +59,8 @@ polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-f
 pallet-xcm = { git = 'https://github.com/paritytech/polkadot', default-features = false, branch = "release-v0.9.43" }
 xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.43" }
 xcm-executor = { git = 'https://github.com/paritytech/polkadot', default-features = false, branch = "release-v0.9.43" }
+
+primitives = { path = "../../primitives", default-features = false }
 
 [features]
 default = ["std"]

--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -271,11 +271,7 @@ pub mod pallet {
 			// If the target_asset is a token from this chain
 			// use the ReserveAssetDeposited instruction;
 			// otherwise, use the WithdrawAsset instruction.
-			let asset_reserve = T::ReserveProvider::reserve(&local_asset);
-			if asset_reserve.is_none() {
-				return Err(Error::<T>::InvalidAssetLocation.into())
-			}
-			let reserve = asset_reserve.unwrap();
+			let reserve = T::ReserveProvider::reserve(&local_asset).ok_or(Error::<T>::InvalidAssetLocation)?;
 			let asset_reception_instruction = if reserve == T::SelfLocation::get() {
 				ReserveAssetDeposited::<()>(target_asset.clone().into())
 			} else if reserve == destination {

--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -273,7 +273,7 @@ pub mod pallet {
 			// otherwise, use the WithdrawAsset instruction.
 			let reserve = T::ReserveProvider::reserve(&local_asset)
 				.ok_or(Error::<T>::InvalidAssetLocation)?;
-			let asset_reception_instruction = if reserve == T::SelfLocation::get() {
+			let asset_reception_instruction = if reserve == MultiLocation::here() {
 				ReserveAssetDeposited::<()>(target_asset.clone().into())
 			} else if reserve == destination {
 				WithdrawAsset::<()>(target_asset.clone().into())

--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -271,7 +271,8 @@ pub mod pallet {
 			// If the target_asset is a token from this chain
 			// use the ReserveAssetDeposited instruction;
 			// otherwise, use the WithdrawAsset instruction.
-			let reserve = T::ReserveProvider::reserve(&local_asset).ok_or(Error::<T>::InvalidAssetLocation)?;
+			let reserve = T::ReserveProvider::reserve(&local_asset)
+				.ok_or(Error::<T>::InvalidAssetLocation)?;
 			let asset_reception_instruction = if reserve == T::SelfLocation::get() {
 				ReserveAssetDeposited::<()>(target_asset.clone().into())
 			} else if reserve == destination {

--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -272,7 +272,7 @@ pub mod pallet {
 			// otherwise, use the WithdrawAsset instruction.
 			let asset_reserve = T::ReserveProvider::reserve(&local_asset);
 			if asset_reserve.is_none() {
-				return Err(Error::<T>::InvalidAssetLocation.into());
+				return Err(Error::<T>::InvalidAssetLocation.into())
 			}
 			let reserve = asset_reserve.unwrap();
 			let asset_reception_instruction = if reserve == T::SelfLocation::get() {
@@ -280,7 +280,7 @@ pub mod pallet {
 			} else if reserve == destination {
 				WithdrawAsset::<()>(target_asset.clone().into())
 			} else {
-				return Err(Error::<T>::UnsupportedFeePayment.into());
+				return Err(Error::<T>::UnsupportedFeePayment.into())
 			};
 
 			let target_xcm = Xcm(vec![

--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -228,9 +228,12 @@ pub mod pallet {
 			Ok(instructions)
 		}
 
-		fn get_local_xcm(asset: MultiAsset, destination: MultiLocation) -> Result<xcm::latest::Xcm<<T as pallet::Config>::RuntimeCall>, DispatchError> {
-			let reserve = T::ReserveProvider::reserve(&asset)
-				.ok_or(Error::<T>::InvalidAssetLocation)?;
+		fn get_local_xcm(
+			asset: MultiAsset,
+			destination: MultiLocation,
+		) -> Result<xcm::latest::Xcm<<T as pallet::Config>::RuntimeCall>, DispatchError> {
+			let reserve =
+				T::ReserveProvider::reserve(&asset).ok_or(Error::<T>::InvalidAssetLocation)?;
 			let local_xcm = if reserve == MultiLocation::here() {
 				Xcm(vec![
 					WithdrawAsset::<<T as pallet::Config>::RuntimeCall>(asset.into()),
@@ -285,7 +288,7 @@ pub mod pallet {
 
 			let local_xcm = Self::get_local_xcm(local_asset.clone(), destination.clone())?;
 
-				// XCM for target chain
+			// XCM for target chain
 			let target_asset = local_asset
 				.clone()
 				.reanchored(&destination, T::UniversalLocation::get())

--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -46,7 +46,6 @@ use xcm::latest::prelude::*;
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::traits::Currency;
 	use orml_traits::{location::Reserve, MultiCurrency};
 	use polkadot_parachain::primitives::Sibling;
 	use sp_runtime::traits::{AccountIdConversion, Convert, SaturatedConversion};
@@ -167,7 +166,9 @@ pub mod pallet {
 		BadVersion,
 		// Asset not found
 		TransactInfoNotFound,
+		// Invalid asset location.
 		InvalidAssetLocation,
+		// The fee payment asset location is not supported.
 		UnsupportedFeePayment,
 	}
 

--- a/pallets/xcmp-handler/src/mock.rs
+++ b/pallets/xcmp-handler/src/mock.rs
@@ -41,10 +41,7 @@ use xcm_executor::{
 	Assets, XcmExecutor,
 };
 
-use orml_traits::{
-	location::AbsoluteReserveProvider, parameter_type_with_key, FixedConversionRateProvider,
-	MultiCurrency,
-};
+use orml_traits::parameter_type_with_key;
 
 use primitives::AbsoluteAndRelativeReserveProvider;
 

--- a/pallets/xcmp-handler/src/mock.rs
+++ b/pallets/xcmp-handler/src/mock.rs
@@ -41,6 +41,13 @@ use xcm_executor::{
 	Assets, XcmExecutor,
 };
 
+use orml_traits::{
+	location::AbsoluteReserveProvider, parameter_type_with_key, FixedConversionRateProvider,
+	MultiCurrency,
+};
+
+use primitives::AbsoluteAndRelativeReserveProvider;
+
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
 pub type AccountId = AccountId32;
@@ -63,6 +70,8 @@ frame_support::construct_runtime!(
 		XcmpHandler: pallet_xcmp_handler::{Pallet, Call, Storage, Event<T>},
 		XcmPallet: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin},
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Call, Event<T>, Origin},
+		Currencies: orml_currencies::{Pallet, Call},
+		Tokens: orml_tokens::{Pallet, Storage, Event<T>, Config<T>},
 	}
 );
 
@@ -124,6 +133,34 @@ impl pallet_balances::Config for Test {
 }
 
 impl parachain_info::Config for Test {}
+
+parameter_type_with_key! {
+	pub ExistentialDeposits: |_currency_id: CurrencyId| -> Balance {
+		Default::default()
+	};
+}
+
+impl orml_tokens::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type Balance = Balance;
+	type Amount = i64;
+	type CurrencyId = CurrencyId;
+	type WeightInfo = ();
+	type ExistentialDeposits = ExistentialDeposits;
+	type CurrencyHooks = ();
+	type MaxLocks = ConstU32<100_000>;
+	type MaxReserves = ConstU32<100_000>;
+	type ReserveIdentifier = [u8; 8];
+	type DustRemovalWhitelist = frame_support::traits::Nothing;
+}
+
+impl orml_currencies::Config for Test {
+	type MultiCurrency = Tokens;
+	type NativeCurrency = AdaptedBasicCurrency;
+	type GetNativeCurrencyId = GetNativeCurrencyId;
+	type WeightInfo = ();
+}
+pub type AdaptedBasicCurrency = orml_currencies::BasicCurrencyAdapter<Test, Balances, i64, u64>;
 
 pub struct AccountIdToMultiLocation;
 impl Convert<AccountId, MultiLocation> for AccountIdToMultiLocation {
@@ -306,13 +343,14 @@ impl Convert<CurrencyId, Option<MultiLocation>> for TokenIdConvert {
 parameter_types! {
 	pub const GetNativeCurrencyId: CurrencyId = NATIVE;
 	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
+	pub SelfLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into())));
 }
 
 impl pallet_xcmp_handler::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
 	type CurrencyId = CurrencyId;
-	type Currency = Balances;
+	type MultiCurrency = Currencies;
 	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type SelfParaId = parachain_info::Pallet<Test>;
 	type AccountIdToMultiLocation = AccountIdToMultiLocation;
@@ -321,6 +359,8 @@ impl pallet_xcmp_handler::Config for Test {
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmSender = TestSendXcm;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
+	type SelfLocation = SelfLocation;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/pallets/xcmp-handler/src/tests.rs
+++ b/pallets/xcmp-handler/src/tests.rs
@@ -218,10 +218,11 @@ fn pay_xcm_fee_works() {
 			Sibling::from(LOCAL_PARA_ID).into_account_truncating();
 		let fee = 3_500_000;
 		let alice_balance = 8_000_000;
+		let currency_id = 0;
 
 		Balances::force_set_balance(RawOrigin::Root.into(), ALICE, alice_balance).unwrap();
 
-		assert_ok!(XcmpHandler::pay_xcm_fee(ALICE, fee));
+		assert_ok!(XcmpHandler::pay_xcm_fee(currency_id, ALICE, fee));
 		assert_eq!(Balances::free_balance(ALICE), alice_balance - fee);
 		assert_eq!(Balances::free_balance(local_sovereign_account), fee);
 	});
@@ -234,10 +235,11 @@ fn pay_xcm_fee_keeps_wallet_alive() {
 			Sibling::from(LOCAL_PARA_ID).into_account_truncating();
 		let fee = 3_500_000;
 		let alice_balance = fee;
+		let currency_id = 0;
 
 		Balances::force_set_balance(RawOrigin::Root.into(), ALICE, alice_balance).unwrap();
 
-		assert_ok!(XcmpHandler::pay_xcm_fee(ALICE, fee));
+		assert_ok!(XcmpHandler::pay_xcm_fee(currency_id, ALICE, fee));
 		assert_eq!(Balances::free_balance(ALICE), alice_balance);
 		assert_eq!(Balances::free_balance(local_sovereign_account), 0);
 	});

--- a/pallets/xcmp-handler/src/tests.rs
+++ b/pallets/xcmp-handler/src/tests.rs
@@ -138,8 +138,6 @@ fn transact_in_local_chain_works() {
 					asset.clone(),
 					MultiLocation { parents: 1, interior: X1(Parachain(LOCAL_PARA_ID)) }
 				),
-				// Depositing asset
-				(asset, MultiLocation { parents: 1, interior: X1(Parachain(PARA_ID)) }),
 			]
 		);
 		assert_eq!(events(), [RuntimeEvent::XcmpHandler(crate::Event::XcmTransactedLocally)]);

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -15,9 +15,22 @@ codec = { package = "parity-scale-codec", version = "3.0.0", features = [
 scale-info = { version = "2.1", default-features = false, features = [
   "derive",
 ] }
+
+# Substrate Dependencies
+## Substrate Primitive Dependencies
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43", default-features = false }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.43" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.43" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.43" }
+
+## Substrate FRAME Dependencies
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.43" }
+
+## Polkdadot deps
+xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.43", default-features = false }
+
+## ORML deps
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", default-features = false, branch = "polkadot-v0.9.43" }
 
 [features]
 default = ["std"]

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -1213,9 +1213,10 @@ impl_runtime_apis! {
 			let fee_handler = <Self as pallet_automation_time::Config>::FeeHandler::new(&nobody, &action, executions)
 				.map_err(|_| "Unable to parse fee".as_bytes())?;
 
+			let execution_fee = fee_handler.execution_fee.map(|fee| fee.amount).unwrap_or(0);
 			Ok(AutomationFeeDetails {
 				schedule_fee: fee_handler.schedule_fee_amount,
-				execution_fee: fee_handler.execution_fee_amount
+				execution_fee,
 			})
 		}
 

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -48,6 +48,8 @@ use xcm::latest::{prelude::*, MultiLocation, NetworkId};
 use xcm_builder::Account32Hash;
 use xcm_executor::traits::Convert;
 
+use orml_traits::location::AbsoluteReserveProvider;
+
 use frame_support::{
 	construct_runtime,
 	dispatch::DispatchClass,
@@ -81,7 +83,7 @@ use polkadot_runtime_common::BlockHashCount;
 
 // XCM configurations.
 pub mod xcm_config;
-use xcm_config::{FeePerSecondProvider, ToTreasury, TokenIdConvert};
+use xcm_config::{FeePerSecondProvider, SelfLocation, ToTreasury, TokenIdConvert};
 
 pub mod weights;
 
@@ -919,8 +921,9 @@ impl pallet_automation_time::Config for Runtime {
 	type ScheduleAllowList = ScheduleAllowList;
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;
-	type SelfParaId = parachain_info::Pallet<Runtime>;
 	type TransferCallCreator = MigrationTransferCallCreator;
+	type ReserveProvider = AbsoluteReserveProvider;
+	type SelfLocation = SelfLocation;
 }
 
 impl pallet_automation_price::Config for Runtime {
@@ -1215,7 +1218,7 @@ impl_runtime_apis! {
 
 			let execution_fee = fee_handler.execution_fee.map(|fee| fee.amount).unwrap_or(0);
 			Ok(AutomationFeeDetails {
-				schedule_fee: fee_handler.schedule_fee_amount,
+				schedule_fee: fee_handler.schedule_fee.amount,
 				execution_fee,
 			})
 		}

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -102,8 +102,8 @@ use common_runtime::{
 	CurrencyHooks,
 };
 use primitives::{
-	AccountId, Address, Amount, AuraId, Balance, BlockNumber, EnsureProxy, Hash, Header, Index,
-	Signature, TransferCallCreator,
+	AbsoluteAndRelativeReserveProvider, AccountId, Address, Amount, AuraId, Balance, BlockNumber,
+	EnsureProxy, Hash, Header, Index, Signature, TransferCallCreator,
 };
 
 // Custom pallet imports
@@ -922,7 +922,7 @@ impl pallet_automation_time::Config for Runtime {
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;
 	type TransferCallCreator = MigrationTransferCallCreator;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
 	type SelfLocation = SelfLocation;
 }
 

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -48,8 +48,6 @@ use xcm::latest::{prelude::*, MultiLocation, NetworkId};
 use xcm_builder::Account32Hash;
 use xcm_executor::traits::Convert;
 
-use orml_traits::location::AbsoluteReserveProvider;
-
 use frame_support::{
 	construct_runtime,
 	dispatch::DispatchClass,

--- a/runtime/neumann/src/xcm_config.rs
+++ b/runtime/neumann/src/xcm_config.rs
@@ -36,6 +36,8 @@ use orml_xcm_support::{
 	DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset,
 };
 
+use primitives::AbsoluteAndRelativeReserveProvider;
+
 parameter_types! {
 	pub const RelayLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Rococo;
@@ -285,7 +287,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type UniversalLocation = UniversalLocation;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
 }
 
 impl orml_unknown_tokens::Config for Runtime {
@@ -309,7 +311,7 @@ impl pallet_xcmp_handler::Config for Runtime {
 	type XcmSender = XcmRouter;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
 	type SelfLocation = SelfLocation;
 }
 

--- a/runtime/neumann/src/xcm_config.rs
+++ b/runtime/neumann/src/xcm_config.rs
@@ -301,7 +301,7 @@ impl pallet_xcmp_handler::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type CurrencyId = TokenId;
 	type GetNativeCurrencyId = GetNativeCurrencyId;
-	type Currency = pallet_balances::Pallet<Runtime>;
+	type MultiCurrency = Currencies;
 	type SelfParaId = parachain_info::Pallet<Runtime>;
 	type AccountIdToMultiLocation = AccountIdToMultiLocation;
 	type CurrencyIdToMultiLocation = TokenIdConvert;

--- a/runtime/neumann/src/xcm_config.rs
+++ b/runtime/neumann/src/xcm_config.rs
@@ -287,7 +287,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type UniversalLocation = UniversalLocation;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
-	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
+	type ReserveProvider = AbsoluteReserveProvider;
 }
 
 impl orml_unknown_tokens::Config for Runtime {

--- a/runtime/neumann/src/xcm_config.rs
+++ b/runtime/neumann/src/xcm_config.rs
@@ -309,6 +309,8 @@ impl pallet_xcmp_handler::Config for Runtime {
 	type XcmSender = XcmRouter;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
+	type ReserveProvider = AbsoluteReserveProvider;
+	type SelfLocation = SelfLocation;
 }
 
 pub struct TokenIdConvert;

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -49,8 +49,6 @@ use xcm::latest::{prelude::*, MultiLocation};
 use xcm_builder::Account32Hash;
 use xcm_executor::traits::Convert;
 
-use orml_traits::location::AbsoluteReserveProvider;
-
 use sp_std::{cmp::Ordering, prelude::*};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -49,6 +49,8 @@ use xcm::latest::{prelude::*, MultiLocation};
 use xcm_builder::Account32Hash;
 use xcm_executor::traits::Convert;
 
+use orml_traits::location::AbsoluteReserveProvider;
+
 use sp_std::{cmp::Ordering, prelude::*};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -87,7 +89,7 @@ use polkadot_runtime_common::BlockHashCount;
 
 // XCM configurations.
 pub mod xcm_config;
-use xcm_config::{FeePerSecondProvider, ToTreasury, TokenIdConvert};
+use xcm_config::{FeePerSecondProvider, SelfLocation, ToTreasury, TokenIdConvert};
 
 pub mod weights;
 
@@ -944,8 +946,9 @@ impl pallet_automation_time::Config for Runtime {
 	type ScheduleAllowList = ScheduleAllowList;
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;
-	type SelfParaId = parachain_info::Pallet<Runtime>;
 	type TransferCallCreator = MigrationTransferCallCreator;
+	type ReserveProvider = AbsoluteReserveProvider;
+	type SelfLocation = SelfLocation;
 }
 
 impl pallet_automation_price::Config for Runtime {
@@ -1244,7 +1247,7 @@ impl_runtime_apis! {
 
 			let execution_fee = fee_handler.execution_fee.map(|fee| fee.amount).unwrap_or(0);
 			Ok(AutomationFeeDetails {
-				schedule_fee: fee_handler.schedule_fee_amount,
+				schedule_fee: fee_handler.schedule_fee.amount,
 				execution_fee,
 			})
 		}

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -1242,9 +1242,10 @@ impl_runtime_apis! {
 			let fee_handler = <Self as pallet_automation_time::Config>::FeeHandler::new(&nobody, &action, executions)
 				.map_err(|_| "Unable to parse fee".as_bytes())?;
 
+			let execution_fee = fee_handler.execution_fee.map(|fee| fee.amount).unwrap_or(0);
 			Ok(AutomationFeeDetails {
 				schedule_fee: fee_handler.schedule_fee_amount,
-				execution_fee: fee_handler.execution_fee_amount
+				execution_fee,
 			})
 		}
 

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -32,7 +32,7 @@ use pallet_automation_time_rpc_runtime_api::{
 // to their standalone Fee RPC that can handle both
 use pallet_automation_price_rpc_runtime_api::FeeDetails as AutomationPriceFeeDetails;
 
-use primitives::{assets::CustomMetadata, TokenId};
+use primitives::{assets::CustomMetadata, AbsoluteAndRelativeReserveProvider, TokenId};
 use scale_info::prelude::format;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
@@ -947,7 +947,7 @@ impl pallet_automation_time::Config for Runtime {
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;
 	type TransferCallCreator = MigrationTransferCallCreator;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
 	type SelfLocation = SelfLocation;
 }
 

--- a/runtime/oak/src/xcm_config.rs
+++ b/runtime/oak/src/xcm_config.rs
@@ -313,6 +313,8 @@ impl pallet_xcmp_handler::Config for Runtime {
 	type XcmSender = XcmRouter;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
+	type ReserveProvider = AbsoluteReserveProvider;
+	type SelfLocation = SelfLocation;
 }
 
 pub struct TokenIdConvert;

--- a/runtime/oak/src/xcm_config.rs
+++ b/runtime/oak/src/xcm_config.rs
@@ -291,7 +291,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type UniversalLocation = UniversalLocation;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
-	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
+	type ReserveProvider = AbsoluteReserveProvider;
 }
 
 impl orml_unknown_tokens::Config for Runtime {

--- a/runtime/oak/src/xcm_config.rs
+++ b/runtime/oak/src/xcm_config.rs
@@ -303,7 +303,7 @@ parameter_types! {
 impl pallet_xcmp_handler::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type Currency = pallet_balances::Pallet<Runtime>;
+	type MultiCurrency = Currencies;
 	type CurrencyId = TokenId;
 	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type SelfParaId = parachain_info::Pallet<Runtime>;

--- a/runtime/oak/src/xcm_config.rs
+++ b/runtime/oak/src/xcm_config.rs
@@ -38,6 +38,8 @@ use orml_xcm_support::{
 	DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset,
 };
 
+use primitives::AbsoluteAndRelativeReserveProvider;
+
 parameter_types! {
 	pub const RelayLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Polkadot;
@@ -289,7 +291,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type UniversalLocation = UniversalLocation;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
 }
 
 impl orml_unknown_tokens::Config for Runtime {
@@ -313,7 +315,7 @@ impl pallet_xcmp_handler::Config for Runtime {
 	type XcmSender = XcmRouter;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
 	type SelfLocation = SelfLocation;
 }
 

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -1358,9 +1358,10 @@ impl_runtime_apis! {
 			let fee_handler = <Self as pallet_automation_time::Config>::FeeHandler::new(&nobody, &action, executions)
 				.map_err(|_| "Unable to parse fee".as_bytes())?;
 
+			let execution_fee = fee_handler.execution_fee.map(|fee| fee.amount).unwrap_or(0);
 			Ok(AutomationFeeDetails {
 				schedule_fee: fee_handler.schedule_fee_amount,
-				execution_fee: fee_handler.execution_fee_amount
+				execution_fee,
 			})
 		}
 

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -48,6 +48,8 @@ use xcm::latest::{prelude::*, MultiLocation};
 use xcm_builder::Account32Hash;
 use xcm_executor::traits::Convert;
 
+use orml_traits::location::AbsoluteReserveProvider;
+
 use sp_std::{cmp::Ordering, prelude::*};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -84,7 +86,7 @@ use polkadot_runtime_common::BlockHashCount;
 
 // XCM configurations.
 pub mod xcm_config;
-use xcm_config::{FeePerSecondProvider, ToTreasury, TokenIdConvert};
+use xcm_config::{FeePerSecondProvider, SelfLocation, ToTreasury, TokenIdConvert};
 
 pub mod weights;
 
@@ -1061,8 +1063,9 @@ impl pallet_automation_time::Config for Runtime {
 	type ScheduleAllowList = ScheduleAllowList;
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;
-	type SelfParaId = parachain_info::Pallet<Runtime>;
 	type TransferCallCreator = MigrationTransferCallCreator;
+	type ReserveProvider = AbsoluteReserveProvider;
+	type SelfLocation = SelfLocation;
 }
 
 impl pallet_automation_price::Config for Runtime {
@@ -1360,7 +1363,7 @@ impl_runtime_apis! {
 
 			let execution_fee = fee_handler.execution_fee.map(|fee| fee.amount).unwrap_or(0);
 			Ok(AutomationFeeDetails {
-				schedule_fee: fee_handler.schedule_fee_amount,
+				schedule_fee: fee_handler.schedule_fee.amount,
 				execution_fee,
 			})
 		}

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -48,8 +48,6 @@ use xcm::latest::{prelude::*, MultiLocation};
 use xcm_builder::Account32Hash;
 use xcm_executor::traits::Convert;
 
-use orml_traits::location::AbsoluteReserveProvider;
-
 use sp_std::{cmp::Ordering, prelude::*};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -31,7 +31,7 @@ use pallet_automation_price_rpc_runtime_api::FeeDetails as AutomationPriceFeeDet
 use pallet_automation_time_rpc_runtime_api::{
 	AutomationAction, AutostakingResult, FeeDetails as AutomationFeeDetails,
 };
-use primitives::{assets::CustomMetadata, TokenId};
+use primitives::{assets::CustomMetadata, AbsoluteAndRelativeReserveProvider, TokenId};
 use scale_info::prelude::format;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
@@ -1064,7 +1064,7 @@ impl pallet_automation_time::Config for Runtime {
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;
 	type TransferCallCreator = MigrationTransferCallCreator;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
 	type SelfLocation = SelfLocation;
 }
 

--- a/runtime/turing/src/xcm_config.rs
+++ b/runtime/turing/src/xcm_config.rs
@@ -313,6 +313,8 @@ impl pallet_xcmp_handler::Config for Runtime {
 	type XcmSender = XcmRouter;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
+	type ReserveProvider = AbsoluteReserveProvider;
+	type SelfLocation = SelfLocation;
 }
 
 pub struct TokenIdConvert;

--- a/runtime/turing/src/xcm_config.rs
+++ b/runtime/turing/src/xcm_config.rs
@@ -37,6 +37,8 @@ use orml_xcm_support::{
 	DepositToAlternative, IsNativeConcrete, MultiCurrencyAdapter, MultiNativeAsset,
 };
 
+use primitives::AbsoluteAndRelativeReserveProvider;
+
 parameter_types! {
 	pub const RelayLocation: MultiLocation = MultiLocation::parent();
 	pub const RelayNetwork: NetworkId = NetworkId::Kusama;
@@ -289,7 +291,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type UniversalLocation = UniversalLocation;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
 }
 
 impl orml_unknown_tokens::Config for Runtime {
@@ -313,7 +315,7 @@ impl pallet_xcmp_handler::Config for Runtime {
 	type XcmSender = XcmRouter;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
 	type SelfLocation = SelfLocation;
 }
 

--- a/runtime/turing/src/xcm_config.rs
+++ b/runtime/turing/src/xcm_config.rs
@@ -291,7 +291,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type UniversalLocation = UniversalLocation;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
-	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
+	type ReserveProvider = AbsoluteReserveProvider;
 }
 
 impl orml_unknown_tokens::Config for Runtime {

--- a/runtime/turing/src/xcm_config.rs
+++ b/runtime/turing/src/xcm_config.rs
@@ -303,7 +303,7 @@ parameter_types! {
 impl pallet_xcmp_handler::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type RuntimeCall = RuntimeCall;
-	type Currency = pallet_balances::Pallet<Runtime>;
+	type MultiCurrency = Currencies;
 	type CurrencyId = TokenId;
 	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type SelfParaId = parachain_info::Pallet<Runtime>;


### PR DESCRIPTION
We have implemented the functionality to specify different currencies as the execution fee.

Based on whether the currency is native or foreign, we have employed different processing flows and XCM instructions.