### PR TITLE
Adjust the parameters for burning tokens

### DIFF
--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -820,8 +820,8 @@ parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 1 * DOLLAR;
 	pub const ProposalBondMaximum: Balance = 5 * DOLLAR;
-	pub const SpendPeriod: BlockNumber = 1 * DAYS;
-	pub const Burn: Permill = Permill::from_percent(0);
+	pub const SpendPeriod: BlockNumber = 7 * DAYS;
+	pub const Burn: Permill = Permill::from_percent(100);
 	pub const TipCountdown: BlockNumber = 1 * DAYS;
 	pub const TipFindersFee: Percent = Percent::from_percent(20);
 	pub const TipReportDepositBase: Balance = 1 * UNIT;


### PR DESCRIPTION
Testing in the development environment.
I set `SpendPeriod` to 1 MINUTE and `Burn` to 100%. I transferred 1000 TUR to the Treasury account: `68d8VZxMCLRDPBCCT67VEBVAamG1uozgWj3bHxCTv6iZcbYN`.

<img width="1303" alt="image" src="https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/3c0ff198-a9d9-4bb8-895c-40d705c60774">

After the `SpendPeriod` interval, all tokens in the Treasury account were burned.

<img width="599" alt="image" src="https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/ac1e619c-2ca0-4310-900f-8b411d01af38">
<img width="1301" alt="image" src="https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/c8c92b35-f7a4-438e-a3fd-4d0bf901a9da">
