### PR TITLE
Remove xcmp_handler in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       pallet:
         description: provided a list of pallet to run benchmark on
-        default: 'automation_time,automation_price,vesting,valve,xcmp_handler'
+        default: 'automation_time,automation_price,vesting,valve'
         required: true
 
 concurrency:


### PR DESCRIPTION
We have removed the benchmarking.rs file from the xcmp_handler pallet in the following PR because all extrinsic call interfaces (such as set_asset_config) have been removed from this pallet.

https://github.com/OAK-Foundation/OAK-blockchain/pull/366

There is no need to specify running benchmarks for this pallet in benchmark.yml anymore.

Because the benchmarking.rs file no longer exists, an error will occur when GitHub Actions run.

https://github.com/OAK-Foundation/OAK-blockchain/actions/runs/7014798037/job/19083688075


