### PR TITLE
Add summary section to weight template to fix weights in PR

### DIFF
--- a/.maintain/frame-weight-template.hbs
+++ b/.maintain/frame-weight-template.hbs
@@ -12,6 +12,11 @@
 // {{arg}}
 {{/each}}
 
+// Summary:
+{{#each benchmarks as |benchmark|}}
+//:{{benchmark.name}} {{underscore benchmark.base_weight}},{{benchmark.base_calculated_proof_size}}
+{{/each}}
+
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]


### PR DESCRIPTION
In this PR, we only have the weights from the previous version, but not the weights from the current version. 
https://github.com/OAK-Foundation/OAK-blockchain/pull/467

We need to include a summary section in the template to generate the correct text.

It would generate these lines:

```
// Summary:
//:schedule_xcmp_task_full 130_899_385
//:schedule_auto_compound_delegated_stake_task_full 95_776_000
//:schedule_dynamic_dispatch_task 72_653_946
//:schedule_dynamic_dispatch_task_full 82_034_398
//:cancel_scheduled_task_full 979_075_000
//:force_cancel_scheduled_task 27_445_000
//:force_cancel_scheduled_task_full 982_347_000
//:run_xcmp_task 41_572_000
//:run_auto_compound_delegated_stake_task 63_602_000
//:run_dynamic_dispatch_action 8_164_000
//:run_dynamic_dispatch_action_fail_decode 785_000
//:run_missed_tasks_many_found 311_838
//:run_missed_tasks_many_missing 294_793
//:run_tasks_many_found 3_768_036
//:run_tasks_many_missing 2_862_924
//:update_task_queue_overhead 2_761_000
//:append_to_missed_tasks 3_209_620
//:update_scheduled_task_queue 35_844_000
//:shift_missed_tasks 32_373_000
```

https://github.com/OAK-Foundation/OAK-blockchain/blob/b4903cb48628b6776f41beb28a880d2c9e130773/pallets/automation-time/src/weights.rs#L48-L67