### PR TITLE
Bump to node version 2.1.0 and impl version 0(spec_version: 296)

### DIFF
--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -173,10 +173,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("neumann"),
 	impl_name: create_runtime_str!("neumann"),
 	authoring_version: 1,
-	spec_version: 295,
-	impl_version: 2,
+	spec_version: 296,
+	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 17,
+	transaction_version: 19,
 	state_version: 0,
 };
 

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -179,10 +179,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("oak"),
 	impl_name: create_runtime_str!("oak"),
 	authoring_version: 1,
-	spec_version: 295,
-	impl_version: 2,
+	spec_version: 296,
+	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 18,
+	transaction_version: 19,
 	state_version: 0,
 };
 

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -303,10 +303,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("turing"),
 	impl_name: create_runtime_str!("turing"),
 	authoring_version: 1,
-	spec_version: 295,
-	impl_version: 2,
+	spec_version: 296,
+	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 18,
+	transaction_version: 19,
 	state_version: 0,
 };
 


### PR DESCRIPTION
Spec version : 296
Impl version : 0
Transaction version: 19 (Added automation-price pallet)
Node upgrade required: Yes ([Update polkadot-v0.9.43](https://github.com/OAK-Foundation/OAK-blockchain/pull/456/files#top))