### PR TITLE
Upgrade paritytech/srtool version to 1.70.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         uses: chevdor/srtool-actions@v0.5.0
         with:
           chain: ${{ matrix.chain }}
-          tag: 1.66.1
+          tag: 1.70.0
       - name: Summary
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain }}-srtool-digest.json


### PR DESCRIPTION
After upgrading to `polkadot-v0.9.43`, it is necessary to correspondingly upgrade the `paritytech/srtool` version to 1.70.0 in order to compile the code using `rustc` 1.70.0 to fix compilation error.

https://github.com/OAK-Foundation/OAK-blockchain/actions/runs/7055993711/job/19207306507