### PR TITLE
Bump to node version 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5525,7 +5525,7 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "oak-node"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "async-trait",
  "clap",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oak-node"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["OAK Developement Team"]
 description = "Automation-first Blockchain"
 license = "GPL-3.0"


### PR DESCRIPTION
Because I forgot to update the version in the node crate to 2.1.0 earlier, we need to rebuild the release.

Steps:
1. Merge this PR into master.
2. Tag the current commit as v2.1.0.
3. Delete the release draft for 2.1.0 from the releases.
4. Run the build release action; it will automatically build the release, generating a new draft for 2.1.0.