### PR TITLE
Remove the code migrated to runtime 296

### DIFF
--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -139,121 +139,6 @@ pub type UncheckedExtrinsic =
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
 
-/// The runtime migrations per release.
-#[allow(deprecated, missing_docs)]
-pub mod migrations {
-	use super::*;
-	use frame_support::{
-		pallet_prelude::OptionQuery,
-		storage_alias,
-		traits::{GetStorageVersion, OnRuntimeUpgrade, StorageVersion},
-		Blake2_128Concat, Twox64Concat,
-	};
-	use sp_core::Get;
-	use xcm::{prelude::XcmVersion, VersionedMultiLocation};
-
-	pub type V0943 = (SetStorageVersions, PalletXcmMigrateToV1<Runtime>);
-
-	/// Migrations that set `StorageVersion`s we missed to set.
-	///
-	/// It's *possible* that these pallets have not in fact been migrated to the versions being set,
-	/// which we should keep in mind in the future if we notice any strange behavior.
-	/// We opted to not check exactly what on-chain versions each pallet is at, since it would be
-	/// an involved effort, this is testnet, and no one has complained
-	/// (https://github.com/paritytech/polkadot/issues/6657#issuecomment-1552956439).
-	pub struct SetStorageVersions;
-
-	impl OnRuntimeUpgrade for SetStorageVersions {
-		fn on_runtime_upgrade() -> Weight {
-			let mut writes = 0;
-			let mut reads = 0;
-
-			// Bounties
-			if Bounties::on_chain_storage_version() < 4 {
-				StorageVersion::new(4).put::<Bounties>();
-				writes += 1;
-			}
-			reads += 1;
-
-			// Preimage
-			if Preimage::on_chain_storage_version() < 1 {
-				StorageVersion::new(1).put::<Preimage>();
-				writes += 1;
-			}
-			reads += 1;
-
-			// Scheduler
-			if Scheduler::on_chain_storage_version() == 3 {
-				StorageVersion::new(4).put::<Scheduler>();
-				writes += 1;
-			}
-			reads += 1;
-
-			// Multisig
-			if Multisig::on_chain_storage_version() == 0 {
-				StorageVersion::new(1).put::<Multisig>();
-				writes += 1;
-			}
-			reads += 1;
-
-			// Democracy
-			if Democracy::on_chain_storage_version() == 0 {
-				StorageVersion::new(1).put::<Democracy>();
-				writes += 1;
-			}
-			reads += 1;
-
-			RocksDbWeight::get().reads_writes(reads, writes)
-		}
-	}
-
-	// PalletXcmMigrateToV1
-
-	#[storage_alias]
-	type VersionNotifyTargets<T: pallet_xcm::Config> = StorageDoubleMap<
-		pallet_xcm::Pallet<T>,
-		Twox64Concat,
-		XcmVersion,
-		Blake2_128Concat,
-		VersionedMultiLocation,
-		(QueryId, Weight, XcmVersion),
-		OptionQuery,
-	>;
-
-	const DEFAULT_PROOF_SIZE: u64 = 64 * 1024;
-
-	pub struct PalletXcmMigrateToV1<T>(sp_std::marker::PhantomData<T>);
-	impl<T: pallet_xcm::Config> OnRuntimeUpgrade for PalletXcmMigrateToV1<T> {
-		fn on_runtime_upgrade() -> Weight {
-			if StorageVersion::get::<pallet_xcm::Pallet<T>>() == 0 {
-				log::info!("The pallet_xcm is migrating to version 1");
-				let mut weight = T::DbWeight::get().reads(1);
-
-				// Because the previous migration wasn't executed correctly,
-				// there is incorrect data on the chain with { ref_time: 0, proof_size: 0}.
-				// We will modify it to { ref_time: 0, proof_size: 65535}.
-				let translate = |pre: (u64, Weight, u32)| -> Option<(u64, Weight, u32)> {
-					weight = weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
-					let translated =
-						(pre.0, Weight::from_parts(pre.1.ref_time(), DEFAULT_PROOF_SIZE), pre.2);
-					log::info!("Migrated VersionNotifyTarget {:?} to {:?}", pre, translated);
-					Some(translated)
-				};
-
-				VersionNotifyTargets::<T>::translate_values(translate);
-
-				log::info!("v1 applied successfully");
-				StorageVersion::new(1).put::<pallet_xcm::Pallet<T>>();
-
-				weight.saturating_add(T::DbWeight::get().writes(1))
-			} else {
-				log::warn!("skipping v1, should be removed");
-				T::DbWeight::get().reads(1)
-			}
-		}
-	}
-}
-
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
 	Runtime,
@@ -266,14 +151,7 @@ pub type Executive = frame_executive::Executive<
 
 // All migrations executed on runtime upgrade as a nested tuple of types implementing
 // `OnRuntimeUpgrade`.
-type Migrations = (
-	orml_asset_registry::Migration<Runtime>,
-	orml_unknown_tokens::Migration<Runtime>,
-	// pallet_balances::migration::ResetInactive<Runtime>,
-	// We need to apply this migration again, because `ResetInactive` resets the state again.
-	pallet_balances::migration::MigrateToTrackInactive<Runtime, xcm_config::CheckingAccount>,
-	migrations::V0943,
-);
+type Migrations = ();
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats


### PR DESCRIPTION
Empty the `Migrations` list in the Turing runtime.