### PR TITLE
add Currencies and Utility pallet to AllowList

### DIFF
--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -180,7 +180,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("oak"),
 	authoring_version: 1,
 	spec_version: 296,
-	impl_version: 2,
+	impl_version: 3,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 19,
 	state_version: 0,
@@ -887,6 +887,8 @@ impl Contains<RuntimeCall> for ScheduleAllowList {
 			RuntimeCall::Balances(_) => true,
 			RuntimeCall::XTokens(_) => true,
 			RuntimeCall::ParachainStaking(_) => true,
+			RuntimeCall::Utility(_) => true,
+			RuntimeCall::Currencies(_) => true,
 			_ => false,
 		}
 	}

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -182,7 +182,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("turing"),
 	authoring_version: 1,
 	spec_version: 296,
-	impl_version: 2,
+	impl_version: 3,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 19,
 	state_version: 0,
@@ -882,6 +882,8 @@ impl Contains<RuntimeCall> for ScheduleAllowList {
 			RuntimeCall::Balances(_) => true,
 			RuntimeCall::ParachainStaking(_) => true,
 			RuntimeCall::XTokens(_) => true,
+			RuntimeCall::Utility(_) => true,
+			RuntimeCall::Currencies(_) => true,
 			_ => false,
 		}
 	}


### PR DESCRIPTION
in dynamic dispatch, we may use Utility.batch to bundle multiple call into the same task, therefore we would need to allow this.

similarly with currencies, we don't use it yet, but may need down the line and save us another update.