### PR TITLE
Modify the scheduleAs parameter to be an optional parameter

### DIFF
--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -188,7 +188,7 @@ benchmarks! {
 			.saturating_mul(ED_MULTIPLIER.into())
 			.saturating_mul(DEPOSIT_MULTIPLIER.into());
 		let _ = T::MultiCurrency::deposit(currency_id.into(), &caller, foreign_currency_amount);
-	}: schedule_xcmp_task(RawOrigin::Signed(caller), schedule, Box::new(destination.into()), Box::new(schedule_fee.into()), Box::new(fee), call, Weight::from_parts(1_000, 0), Weight::from_parts(2_000, 0))
+	}: schedule_xcmp_task(RawOrigin::Signed(caller), schedule, Box::new(destination.into()), Box::new(schedule_fee.into()), Box::new(fee), call, Weight::from_parts(1_000, 0), Weight::from_parts(2_000, 0), InstructionSequence::PayThroughSovereignAccount, None)
 
 	schedule_auto_compound_delegated_stake_task_full {
 		let task_weight = <T as Config>::WeightInfo::run_auto_compound_delegated_stake_task().ref_time();

--- a/pallets/automation-time/src/fees.rs
+++ b/pallets/automation-time/src/fees.rs
@@ -19,7 +19,6 @@
 use crate::{AccountOf, Action, ActionOf, Config, Error, MultiBalanceOf, Pallet};
 
 use frame_support::traits::Get;
-use frame_system::RawOrigin;
 use orml_traits::MultiCurrency;
 use pallet_xcmp_handler::{InstructionSequence, XcmpTransactor};
 use sp_runtime::{
@@ -246,6 +245,7 @@ mod tests {
 	use codec::Encode;
 	use frame_benchmarking::frame_support::assert_err;
 	use frame_support::sp_runtime::AccountId32;
+	use frame_system::RawOrigin;
 
 	#[test]
 	fn pay_checked_fees_for_success() {

--- a/pallets/xcmp-handler/src/lib.rs
+++ b/pallets/xcmp-handler/src/lib.rs
@@ -228,32 +228,6 @@ pub mod pallet {
 			Ok(instructions)
 		}
 
-		fn get_local_xcm(
-			asset: MultiAsset,
-			destination: MultiLocation,
-		) -> Result<xcm::latest::Xcm<<T as pallet::Config>::RuntimeCall>, DispatchError> {
-			let reserve =
-				T::ReserveProvider::reserve(&asset).ok_or(Error::<T>::InvalidAssetLocation)?;
-			let local_xcm = if reserve == MultiLocation::here() {
-				Xcm(vec![
-					WithdrawAsset::<<T as pallet::Config>::RuntimeCall>(asset.into()),
-					DepositAsset::<<T as pallet::Config>::RuntimeCall> {
-						assets: Wild(All),
-						beneficiary: destination,
-					},
-				])
-			} else if reserve == destination {
-				Xcm(vec![
-					WithdrawAsset::<<T as pallet::Config>::RuntimeCall>(asset.clone().into()),
-					BurnAsset::<<T as pallet::Config>::RuntimeCall>(asset.into()),
-				])
-			} else {
-				return Err(Error::<T>::UnsupportedFeePayment.into())
-			};
-
-			Ok(local_xcm)
-		}
-
 		/// Construct the instructions for a transact xcm with our local currency.
 		///
 		/// Local instructions

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -1186,19 +1186,11 @@ impl_runtime_apis! {
 
 			let (action, executions) = match uxt.function {
 				RuntimeCall::AutomationTime(pallet_automation_time::Call::schedule_xcmp_task{
-					destination, schedule_fee, execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule, ..
+					destination, schedule_fee, execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule, instruction_sequence, schedule_as, ..
 				}) => {
 					let destination = MultiLocation::try_from(*destination).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
 					let schedule_fee = MultiLocation::try_from(*schedule_fee).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
-					let action = Action::XCMP { destination, schedule_fee, execution_fee: *execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule_as: None, instruction_sequence: InstructionSequence::PayThroughSovereignAccount };
-					Ok((action, schedule.number_of_executions()))
-				},
-				RuntimeCall::AutomationTime(pallet_automation_time::Call::schedule_xcmp_task_through_proxy{
-					destination, schedule_fee, execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule, schedule_as, ..
-				}) => {
-					let destination = MultiLocation::try_from(*destination).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
-					let schedule_fee = MultiLocation::try_from(*schedule_fee).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
-					let action = Action::XCMP { destination, schedule_fee, execution_fee: *execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule_as: Some(schedule_as), instruction_sequence: InstructionSequence::PayThroughRemoteDerivativeAccount };
+					let action = Action::XCMP { destination, schedule_fee, execution_fee: *execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule_as, instruction_sequence };
 					Ok((action, schedule.number_of_executions()))
 				},
 				RuntimeCall::AutomationTime(pallet_automation_time::Call::schedule_dynamic_dispatch_task{

--- a/runtime/neumann/src/xcm_config.rs
+++ b/runtime/neumann/src/xcm_config.rs
@@ -18,7 +18,7 @@ use polkadot_parachain::primitives::Sibling;
 // XCM Imports
 use xcm::latest::{prelude::*, Weight};
 use xcm_builder::{
-	Account32Hash, AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
+	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds,
 	ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
 	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeRevenue,

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -1218,19 +1218,11 @@ impl_runtime_apis! {
 
 			let (action, executions) = match uxt.function {
 				RuntimeCall::AutomationTime(pallet_automation_time::Call::schedule_xcmp_task{
-					destination, schedule_fee, execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule, ..
+					destination, schedule_fee, execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule, instruction_sequence, schedule_as, ..
 				}) => {
 					let destination = MultiLocation::try_from(*destination).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
 					let schedule_fee = MultiLocation::try_from(*schedule_fee).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
-					let action = Action::XCMP { destination, schedule_fee, execution_fee: *execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule_as: None, instruction_sequence: InstructionSequence::PayThroughSovereignAccount };
-					Ok((action, schedule.number_of_executions()))
-				},
-				RuntimeCall::AutomationTime(pallet_automation_time::Call::schedule_xcmp_task_through_proxy{
-					destination, schedule_fee, execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule, schedule_as, ..
-				}) => {
-					let destination = MultiLocation::try_from(*destination).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
-					let schedule_fee = MultiLocation::try_from(*schedule_fee).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
-					let action = Action::XCMP { destination, schedule_fee, execution_fee: *execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule_as: Some(schedule_as), instruction_sequence: InstructionSequence::PayThroughRemoteDerivativeAccount };
+					let action = Action::XCMP { destination, schedule_fee, execution_fee: *execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule_as, instruction_sequence };
 					Ok((action, schedule.number_of_executions()))
 				},
 				RuntimeCall::AutomationTime(pallet_automation_time::Call::schedule_dynamic_dispatch_task{

--- a/runtime/oak/src/xcm_config.rs
+++ b/runtime/oak/src/xcm_config.rs
@@ -20,7 +20,7 @@ use polkadot_parachain::primitives::Sibling;
 // XCM Imports
 use xcm::latest::prelude::*;
 use xcm_builder::{
-	Account32Hash, AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
+	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds,
 	ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
 	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeRevenue,

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -1212,19 +1212,11 @@ impl_runtime_apis! {
 
 			let (action, executions) = match uxt.function {
 				RuntimeCall::AutomationTime(pallet_automation_time::Call::schedule_xcmp_task{
-					destination, schedule_fee, execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule, ..
+					destination, schedule_fee, execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule, instruction_sequence, schedule_as, ..
 				}) => {
 					let destination = MultiLocation::try_from(*destination).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
 					let schedule_fee = MultiLocation::try_from(*schedule_fee).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
-					let action = Action::XCMP { destination, schedule_fee, execution_fee: *execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule_as: None, instruction_sequence: InstructionSequence::PayThroughSovereignAccount };
-					Ok((action, schedule.number_of_executions()))
-				},
-				RuntimeCall::AutomationTime(pallet_automation_time::Call::schedule_xcmp_task_through_proxy{
-					destination, schedule_fee, execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule, schedule_as, ..
-				}) => {
-					let destination = MultiLocation::try_from(*destination).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
-					let schedule_fee = MultiLocation::try_from(*schedule_fee).map_err(|()| "Unable to convert VersionedMultiLocation".as_bytes())?;
-					let action = Action::XCMP { destination, schedule_fee, execution_fee: *execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule_as: Some(schedule_as), instruction_sequence: InstructionSequence::PayThroughRemoteDerivativeAccount };
+					let action = Action::XCMP { destination, schedule_fee, execution_fee: *execution_fee, encoded_call, encoded_call_weight, overall_weight, schedule_as, instruction_sequence };
 					Ok((action, schedule.number_of_executions()))
 				},
 				RuntimeCall::AutomationTime(pallet_automation_time::Call::schedule_dynamic_dispatch_task{

--- a/runtime/turing/src/xcm_config.rs
+++ b/runtime/turing/src/xcm_config.rs
@@ -19,7 +19,7 @@ use polkadot_parachain::primitives::Sibling;
 // XCM Imports
 use xcm::latest::{prelude::*, Weight};
 use xcm_builder::{
-	Account32Hash, AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
+	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds,
 	ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
 	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeRevenue,


### PR DESCRIPTION
We can use the Derivative account as the task executor without the need to add proxy relationships on the Turing chain.