### PR TITLE
Encode extrinsic call. fix #505

### DIFF
--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -223,12 +223,12 @@ benchmarks! {
 		T::Currency::deposit_creating(&caller, account_min.saturating_mul(DEPOSIT_MULTIPLIER.into()));
 
 		let initial_event_count = frame_system::Pallet::<T>::event_count() as u8;
-	}: schedule_dynamic_dispatch_task(RawOrigin::Signed(caller.clone()), schedule, Box::new(call))
+	}: schedule_dynamic_dispatch_task(RawOrigin::Signed(caller.clone()), schedule, Box::new(call.clone()))
 	verify {
 		{
 			//panic!("events count: {:?} final {:?} data:{:?}", initial_event_count, frame_system::Pallet::<T>::event_count(), frame_system::Pallet::<T>::events());
 			// the task id schedule on first block, first extrinsics, but depend on which path in unitest or in benchmark the initial_event_count might be different therefore we get it from the initial state
-			assert_last_event::<T>(Event::TaskScheduled { who: caller, schedule_as: None, task_id: format!("1-0-{:?}", initial_event_count).as_bytes().to_vec(),   }.into())
+			assert_last_event::<T>(Event::TaskScheduled { who: caller, schedule_as: None, task_id: format!("1-0-{:?}", initial_event_count).as_bytes().to_vec(), encoded_call: Some(call.encode()) }.into())
 		}
 	}
 
@@ -251,10 +251,10 @@ benchmarks! {
 		// Almost fill up all time slots
 		schedule_notify_tasks::<T>(caller.clone(), times, T::MaxTasksPerSlot::get() - 1);
 		let initial_event_count = frame_system::Pallet::<T>::event_count() as u8;
-	}: schedule_dynamic_dispatch_task(RawOrigin::Signed(caller.clone()), schedule, Box::new(call))
+	}: schedule_dynamic_dispatch_task(RawOrigin::Signed(caller.clone()), schedule, Box::new(call.clone()))
 	verify {
 		// the task id schedule on first block, first extrinsics, but depend on which path in unitest or in benchmark the initial_event_count might be different therefore we get it from the initial state
-		assert_last_event::<T>(Event::TaskScheduled { who: caller, schedule_as: None, task_id: format!("1-0-{:?}", initial_event_count).as_bytes().to_vec(),   }.into())
+		assert_last_event::<T>(Event::TaskScheduled { who: caller, schedule_as: None, task_id: format!("1-0-{:?}", initial_event_count).as_bytes().to_vec(), encoded_call: Some(call.encode()) }.into())
 	}
 
 	cancel_scheduled_task_full {

--- a/pallets/automation-time/src/benchmarking.rs
+++ b/pallets/automation-time/src/benchmarking.rs
@@ -217,7 +217,7 @@ benchmarks! {
 		let schedule = ScheduleParam::Fixed { execution_times: times };
 
 		let caller: T::AccountId = account("caller", 0, SEED);
-		let call: <T as Config>::Call = frame_system::Call::remark { remark: vec![] }.into();
+		let call: <T as Config>::RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
 
 		let account_min = T::Currency::minimum_balance().saturating_mul(ED_MULTIPLIER.into());
 		T::Currency::deposit_creating(&caller, account_min.saturating_mul(DEPOSIT_MULTIPLIER.into()));
@@ -243,7 +243,7 @@ benchmarks! {
 		let schedule = ScheduleParam::Fixed { execution_times: times.clone() };
 
 		let caller: T::AccountId = account("caller", 0, SEED);
-		let call: <T as Config>::Call = frame_system::Call::remark { remark: vec![] }.into();
+		let call: <T as Config>::RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
 
 		let account_min = T::Currency::minimum_balance().saturating_mul(ED_MULTIPLIER.into());
 		T::Currency::deposit_creating(&caller, account_min.saturating_mul(DEPOSIT_MULTIPLIER.into()));
@@ -347,7 +347,7 @@ benchmarks! {
 	run_dynamic_dispatch_action {
 		let caller: T::AccountId = account("caller", 0, SEED);
 		let task_id = vec![49, 45, 48, 45, 52];
-		let call: <T as Config>::Call = frame_system::Call::remark { remark: vec![] }.into();
+		let call: <T as Config>::RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
 		let encoded_call = call.encode();
 	}: {
 		let (_, error) = AutomationTime::<T>::run_dynamic_dispatch_action(caller.clone(), encoded_call);

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -458,7 +458,7 @@ pub mod pallet {
 				encoded_call_weight,
 				overall_weight,
 				instruction_sequence,
-				schedule_as,
+				schedule_as: schedule_as.clone(),
 			}
 			.into();
 			let encoded_call = call.encode();
@@ -466,7 +466,7 @@ pub mod pallet {
 			Self::deposit_event(Event::<T>::TaskScheduled {
 				who,
 				task_id,
-				schedule_as: Self::get_schedule_as_from_action(action),
+				schedule_as,
 				encoded_call: Some(encoded_call),
 			});
 
@@ -518,7 +518,7 @@ pub mod pallet {
 			Self::deposit_event(Event::<T>::TaskScheduled {
 				who,
 				task_id,
-				schedule_as: Self::get_schedule_as_from_action(action),
+				schedule_as: None,
 				encoded_call: None,
 			});
 
@@ -556,7 +556,7 @@ pub mod pallet {
 			Self::deposit_event(Event::<T>::TaskScheduled {
 				who,
 				task_id,
-				schedule_as: Self::get_schedule_as_from_action(action),
+				schedule_as: None,
 				encoded_call: Some(encoded_call),
 			});
 
@@ -1355,14 +1355,6 @@ pub mod pallet {
 				Commit(Ok(task_id))
 			})
 			.map_err(|_| Error::<T>::TimeSlotFull)
-		}
-
-		/// Get schedule_as from action
-		pub fn get_schedule_as_from_action(action: ActionOf<T>) -> Option<T::AccountId> {
-			match action {
-				Action::XCMP { schedule_as, .. } => schedule_as,
-				_ => None,
-			}
 		}
 
 		/// Validate and schedule task.

--- a/pallets/automation-time/src/lib.rs
+++ b/pallets/automation-time/src/lib.rs
@@ -61,7 +61,6 @@ use frame_system::pallet_prelude::*;
 use orml_traits::{location::Reserve, FixedConversionRateProvider, MultiCurrency};
 use pallet_parachain_staking::DelegatorActions;
 use pallet_timestamp::{self as timestamp};
-// use crate::pallet_automation_time;
 pub use pallet_xcmp_handler::InstructionSequence;
 use pallet_xcmp_handler::XcmpTransactor;
 use primitives::EnsureProxy;
@@ -449,7 +448,7 @@ pub mod pallet {
 				vec![],
 			)?;
 
-			// Tranform the call into a runtime call and encode it.
+			// Convert the call into a runtime call and encode it.
 			let call: <T as crate::Config>::RuntimeCall = Call::schedule_xcmp_task {
 				schedule,
 				destination,

--- a/pallets/automation-time/src/mock.rs
+++ b/pallets/automation-time/src/mock.rs
@@ -529,7 +529,7 @@ impl pallet_automation_time::Config for Test {
 	type FeeHandler = FeeHandler<Test, ()>;
 	type DelegatorActions = MockDelegatorActions<Test, Balances>;
 	type XcmpTransactor = MockXcmpTransactor<Test, Balances>;
-	type Call = RuntimeCall;
+	type RuntimeCall = RuntimeCall;
 	type ScheduleAllowList = ScheduleAllowList;
 	type CurrencyIdConvert = MockTokenIdConvert;
 	type FeeConversionRateProvider = MockConversionRateProvider;

--- a/pallets/automation-time/src/tests.rs
+++ b/pallets/automation-time/src/tests.rs
@@ -1617,8 +1617,6 @@ fn taskid_adjusted_on_extrinsicid_on_same_block() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		let first_caller = AccountId32::new(ALICE);
 		let message: Vec<u8> = vec![2, 4, 5];
-		let call: RuntimeCall =
-			frame_system::Call::remark_with_event { remark: message.clone() }.into();
 
 		let task_id1 = schedule_task(
 			ALICE,
@@ -1641,7 +1639,7 @@ fn taskid_adjusted_on_extrinsicid_on_same_block() {
 				SCHEDULED_TIME + SLOT_SIZE_SECONDS,
 				SCHEDULED_TIME + SLOT_SIZE_SECONDS * 2,
 			],
-			message,
+			message.clone(),
 		);
 		LastTimeSlot::<Test>::put((
 			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 4,
@@ -1651,18 +1649,26 @@ fn taskid_adjusted_on_extrinsicid_on_same_block() {
 		assert_eq!(task_id1, FIRST_TASK_ID.to_vec());
 		assert_eq!(task_id2, vec![49, 45, 50, 51, 52, 45, 56]);
 
+		// Calculate the expected encoded call
+		let expected_encoded_call =
+			Into::<RuntimeCall>::into(frame_system::Call::remark_with_event {
+				remark: message.clone(),
+			})
+			.encode();
+
+		// Find the TaskScheduled event in the event list and verify if the encoded_call within it is correct.
 		assert_has_event(RuntimeEvent::AutomationTime(crate::Event::TaskScheduled {
 			who: first_caller,
 			task_id: FIRST_TASK_ID.to_vec(),
 			schedule_as: None,
-			encoded_call: Some(call.clone().encode()),
+			encoded_call: Some(expected_encoded_call.clone()),
 		}));
 
 		assert_has_event(RuntimeEvent::AutomationTime(crate::Event::TaskScheduled {
 			who: second_caller,
 			task_id: vec![49, 45, 50, 51, 52, 45, 56],
 			schedule_as: None,
-			encoded_call: Some(call.encode()),
+			encoded_call: Some(expected_encoded_call),
 		}));
 	})
 }
@@ -1673,8 +1679,6 @@ fn taskid_adjusted_on_eventindex_on_same_block_from_same_caller() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		let caller = AccountId32::new(ALICE);
 		let message: Vec<u8> = vec![2, 4, 5];
-		let call: RuntimeCall =
-			frame_system::Call::remark_with_event { remark: message.clone() }.into();
 
 		let task_id1 = schedule_task(
 			ALICE,
@@ -1704,18 +1708,26 @@ fn taskid_adjusted_on_eventindex_on_same_block_from_same_caller() {
 		// 1-234-6
 		assert_eq!(task_id2, "1-234-6".as_bytes().to_vec());
 
+		// Calculate the expected encoded call
+		let expected_encoded_call =
+			Into::<RuntimeCall>::into(frame_system::Call::remark_with_event {
+				remark: message.clone(),
+			})
+			.encode();
+
+		// Find the TaskScheduled event in the event list and verify if the encoded_call within it is correct.
 		assert_has_event(RuntimeEvent::AutomationTime(crate::Event::TaskScheduled {
 			who: caller.clone(),
 			task_id: "1-0-3".as_bytes().to_vec(),
 			schedule_as: None,
-			encoded_call: Some(call.clone().encode()),
+			encoded_call: Some(expected_encoded_call.clone()),
 		}));
 
 		assert_has_event(RuntimeEvent::AutomationTime(crate::Event::TaskScheduled {
 			who: caller,
 			task_id: "1-234-6".as_bytes().to_vec(),
 			schedule_as: None,
-			encoded_call: Some(call.encode()),
+			encoded_call: Some(expected_encoded_call),
 		}));
 	})
 }
@@ -1726,8 +1738,6 @@ fn taskid_on_same_extrinsid_have_unique_event_index() {
 	new_test_ext(START_BLOCK_TIME).execute_with(|| {
 		let owner = AccountId32::new(ALICE);
 		let message: Vec<u8> = vec![2, 4, 5];
-		let call: RuntimeCall =
-			frame_system::Call::remark_with_event { remark: message.clone() }.into();
 
 		let task_id1 = schedule_task(
 			ALICE,
@@ -1746,7 +1756,7 @@ fn taskid_on_same_extrinsid_have_unique_event_index() {
 				SCHEDULED_TIME + SLOT_SIZE_SECONDS,
 				SCHEDULED_TIME + SLOT_SIZE_SECONDS * 2,
 			],
-			message,
+			message.clone(),
 		);
 		LastTimeSlot::<Test>::put((
 			SCHEDULED_TIME - SLOT_SIZE_SECONDS * 4,
@@ -1756,11 +1766,17 @@ fn taskid_on_same_extrinsid_have_unique_event_index() {
 		assert_eq!(task_id1, FIRST_TASK_ID.to_vec());
 		assert_eq!(task_id2, SECOND_TASK_ID.to_vec());
 
+		// Calculate the expected encoded call
+		let expected_encoded_call =
+			Into::<RuntimeCall>::into(frame_system::Call::remark_with_event { remark: message })
+				.encode();
+
+		// Find the TaskScheduled event in the event list and verify if the encoded_call within it is correct.
 		assert_has_event(RuntimeEvent::AutomationTime(crate::Event::TaskScheduled {
 			who: owner,
 			task_id: FIRST_TASK_ID.to_vec(),
 			schedule_as: None,
-			encoded_call: Some(call.encode()),
+			encoded_call: Some(expected_encoded_call),
 		}));
 	})
 }

--- a/pallets/automation-time/src/types.rs
+++ b/pallets/automation-time/src/types.rs
@@ -49,8 +49,9 @@ impl<AccountId, Balance> Action<AccountId, Balance> {
 			Action::AutoCompoundDelegatedStake { .. } =>
 				<T as Config>::WeightInfo::run_auto_compound_delegated_stake_task(),
 			Action::DynamicDispatch { encoded_call } => {
-				let scheduled_call: <T as Config>::Call = Decode::decode(&mut &**encoded_call)
-					.map_err(|_| Error::<T>::CallCannotBeDecoded)?;
+				let scheduled_call: <T as Config>::RuntimeCall =
+					Decode::decode(&mut &**encoded_call)
+						.map_err(|_| Error::<T>::CallCannotBeDecoded)?;
 				<T as Config>::WeightInfo::run_dynamic_dispatch_action()
 					.saturating_add(scheduled_call.get_dispatch_info().weight)
 			},

--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -915,7 +915,7 @@ impl pallet_automation_time::Config for Runtime {
 	type DelegatorActions = ParachainStaking;
 	type CurrencyIdConvert = TokenIdConvert;
 	type FeeConversionRateProvider = FeePerSecondProvider;
-	type Call = RuntimeCall;
+	type RuntimeCall = RuntimeCall;
 	type ScheduleAllowList = ScheduleAllowList;
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -943,7 +943,7 @@ impl pallet_automation_time::Config for Runtime {
 	type DelegatorActions = ParachainStaking;
 	type CurrencyIdConvert = TokenIdConvert;
 	type FeeConversionRateProvider = FeePerSecondProvider;
-	type Call = RuntimeCall;
+	type RuntimeCall = RuntimeCall;
 	type ScheduleAllowList = ScheduleAllowList;
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -938,7 +938,7 @@ impl pallet_automation_time::Config for Runtime {
 	type DelegatorActions = ParachainStaking;
 	type CurrencyIdConvert = TokenIdConvert;
 	type FeeConversionRateProvider = FeePerSecondProvider;
-	type Call = RuntimeCall;
+	type RuntimeCall = RuntimeCall;
 	type ScheduleAllowList = ScheduleAllowList;
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;


### PR DESCRIPTION
Update the TaskScheduled event by incorporating the encodedCall and excluding it from the TaskTriggered event.

1. Use the call parameter of scheduleDynamicDispatch as encodedCall.

2. Use the entire extrinsic of scheduleXcmpTask as encodedCall.

**Tests:**

Add `schedule_xcmp_task_and_check_encoded_call_success` test

**Manual testing:**

`TaskTriggered` event:

<img width="677" alt="image" src="https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/4db5ea67-8bb8-4881-9ecd-aab284920549">

Decoded call:

<img width="780" alt="image" src="https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/01a9733a-5a69-4009-b5eb-2b3e85535825">
