### PR TITLE
Fix the issue of xtokens transferring local tokens using relative location

### DIFF
--- a/runtime/neumann/src/lib.rs
+++ b/runtime/neumann/src/lib.rs
@@ -81,7 +81,7 @@ use polkadot_runtime_common::BlockHashCount;
 
 // XCM configurations.
 pub mod xcm_config;
-use xcm_config::{FeePerSecondProvider, SelfLocation, ToTreasury, TokenIdConvert};
+use xcm_config::{FeePerSecondProvider, SelfLocationAbsolute, ToTreasury, TokenIdConvert};
 
 pub mod weights;
 
@@ -920,8 +920,8 @@ impl pallet_automation_time::Config for Runtime {
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;
 	type TransferCallCreator = MigrationTransferCallCreator;
-	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
-	type SelfLocation = SelfLocation;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocationAbsolute>;
+	type SelfLocation = SelfLocationAbsolute;
 }
 
 impl pallet_automation_price::Config for Runtime {

--- a/runtime/neumann/src/xcm_config.rs
+++ b/runtime/neumann/src/xcm_config.rs
@@ -266,7 +266,8 @@ impl cumulus_pallet_dmp_queue::Config for Runtime {
 }
 
 parameter_types! {
-	pub SelfLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into())));
+	pub SelfLocation: MultiLocation = Here.into_location();
+	pub SelfLocationAbsolute: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into())));
 	pub const BaseXcmWeight: Weight = Weight::from_parts(100_000_000, 0);
 	pub const MaxAssetsForTransfer: usize = 1;
 }
@@ -291,7 +292,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type UniversalLocation = UniversalLocation;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocationAbsolute>;
 }
 
 impl orml_unknown_tokens::Config for Runtime {
@@ -315,8 +316,8 @@ impl pallet_xcmp_handler::Config for Runtime {
 	type XcmSender = XcmRouter;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
-	type SelfLocation = SelfLocation;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocationAbsolute>;
+	type SelfLocation = SelfLocationAbsolute;
 }
 
 pub struct TokenIdConvert;

--- a/runtime/oak/src/lib.rs
+++ b/runtime/oak/src/lib.rs
@@ -87,7 +87,7 @@ use polkadot_runtime_common::BlockHashCount;
 
 // XCM configurations.
 pub mod xcm_config;
-use xcm_config::{FeePerSecondProvider, SelfLocation, ToTreasury, TokenIdConvert};
+use xcm_config::{FeePerSecondProvider, SelfLocationAbsolute, ToTreasury, TokenIdConvert};
 
 pub mod weights;
 
@@ -948,8 +948,8 @@ impl pallet_automation_time::Config for Runtime {
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;
 	type TransferCallCreator = MigrationTransferCallCreator;
-	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
-	type SelfLocation = SelfLocation;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocationAbsolute>;
+	type SelfLocation = SelfLocationAbsolute;
 }
 
 impl pallet_automation_price::Config for Runtime {

--- a/runtime/oak/src/xcm_config.rs
+++ b/runtime/oak/src/xcm_config.rs
@@ -270,7 +270,8 @@ impl cumulus_pallet_dmp_queue::Config for Runtime {
 }
 
 parameter_types! {
-	pub SelfLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into())));
+	pub SelfLocation: MultiLocation = Here.into_location();
+	pub SelfLocationAbsolute: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into())));
 	pub const BaseXcmWeight: Weight = Weight::from_parts(100_000_000, 0);
 	pub const MaxAssetsForTransfer: usize = 1;
 }
@@ -295,7 +296,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type UniversalLocation = UniversalLocation;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocationAbsolute>;
 }
 
 impl orml_unknown_tokens::Config for Runtime {
@@ -319,8 +320,8 @@ impl pallet_xcmp_handler::Config for Runtime {
 	type XcmSender = XcmRouter;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
-	type SelfLocation = SelfLocation;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocationAbsolute>;
+	type SelfLocation = SelfLocationAbsolute;
 }
 
 pub struct TokenIdConvert;

--- a/runtime/turing/src/lib.rs
+++ b/runtime/turing/src/lib.rs
@@ -84,7 +84,7 @@ use polkadot_runtime_common::BlockHashCount;
 
 // XCM configurations.
 pub mod xcm_config;
-use xcm_config::{FeePerSecondProvider, SelfLocation, ToTreasury, TokenIdConvert};
+use xcm_config::{FeePerSecondProvider, SelfLocationAbsolute, ToTreasury, TokenIdConvert};
 
 pub mod weights;
 
@@ -943,8 +943,8 @@ impl pallet_automation_time::Config for Runtime {
 	type EnsureProxy = AutomationEnsureProxy;
 	type UniversalLocation = UniversalLocation;
 	type TransferCallCreator = MigrationTransferCallCreator;
-	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
-	type SelfLocation = SelfLocation;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocationAbsolute>;
+	type SelfLocation = SelfLocationAbsolute;
 }
 
 impl pallet_automation_price::Config for Runtime {

--- a/runtime/turing/src/xcm_config.rs
+++ b/runtime/turing/src/xcm_config.rs
@@ -270,7 +270,8 @@ impl cumulus_pallet_dmp_queue::Config for Runtime {
 }
 
 parameter_types! {
-	pub SelfLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into())));
+	pub SelfLocation: MultiLocation = Here.into_location();
+	pub SelfLocationAbsolute: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into())));
 	pub const BaseXcmWeight: Weight = Weight::from_parts(100_000_000, 0);
 	pub const MaxAssetsForTransfer: usize = 1;
 }
@@ -295,7 +296,7 @@ impl orml_xtokens::Config for Runtime {
 	type BaseXcmWeight = BaseXcmWeight;
 	type UniversalLocation = UniversalLocation;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
-	type ReserveProvider = AbsoluteReserveProvider;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocationAbsolute>;
 }
 
 impl orml_unknown_tokens::Config for Runtime {
@@ -319,8 +320,8 @@ impl pallet_xcmp_handler::Config for Runtime {
 	type XcmSender = XcmRouter;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocation>;
-	type SelfLocation = SelfLocation;
+	type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocationAbsolute>;
+	type SelfLocation = SelfLocationAbsolute;
 }
 
 pub struct TokenIdConvert;


### PR DESCRIPTION
References:

https://github.com/AstarNetwork/Astar/blob/8846dae72e702fce8419d755516ea435f4a86b79/runtime/astar/src/xcm_config.rs#L384

```
impl orml_xtokens::Config for Runtime {
    ...
    type SelfLocation = AstarLocation;
    ...
    type ReserveProvider = AbsoluteAndRelativeReserveProvider<AstarLocationAbsolute>;
}
```

**Extrinsic call:**

https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9946#/extrinsics/decode/0x2c0103000000000700e40b540203010200f9200100e659a7a1628cdd93febc04a4e0646ea20e9f5f0ce097d9a05290d4a9e054df4e00

**Screenshoot:**

![image](https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/3d01f9fa-aa54-444f-98b7-40260d00eed0)


![image](https://github.com/OAK-Foundation/OAK-blockchain/assets/16951509/eb0de2b6-f72f-4c59-b55f-1b2bf5ad673c)
